### PR TITLE
This push adds rails functionality to include page spesific javascript i...

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,6 @@
 //= require twitter/bootstrap
 //= require jquery.ui.all
 //= require bootstrap
-//= require_tree .
 //= require redactor.min.js
 //= require redactor_edit_pane.js.coffee
 //= require info_edit.js.coffee
@@ -29,3 +28,4 @@
 //= require editablegrid_renderers.js
 //= require editablegrid_editors.js
 //= require editablegrid_validators.js
+//= require_directory .

--- a/app/assets/javascripts/experiments.js.coffee
+++ b/app/assets/javascripts/experiments.js.coffee
@@ -2,7 +2,7 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
 
-$(document).ready ->
+$ ->
 	
 	$(".liked_status").click ->
 		icon = $(@).children('i')
@@ -15,7 +15,3 @@ $(document).ready ->
 			dataType: "json"
 			success: (resp) =>
 				$(@).siblings(".like_display").html resp['update']
-				
-	$(".add_row_button").click ->
-		editableGrid.addRow(editableGrid.getRowCount()+1,{})
-		console.log window.fields

--- a/app/assets/javascripts/experiments/manualEntry.js.coffee.erb
+++ b/app/assets/javascripts/experiments/manualEntry.js.coffee.erb
@@ -1,0 +1,22 @@
+$ ->
+  editableGrid = {}
+  metadata = []
+  fields = JSON.parse '<%= raw @experiment.fields.to_json%>'
+  data = []
+  row = {}
+  
+  eg = new EditableGrid "Session_Data"
+  
+  console.log window.fields
+  
+  data.push { id: 1, values: row }
+
+  try
+    eg.load { metadata: metadata, data: data }
+    eg.renderGrid "manual_upload_table", "testgrid table"
+  catch error
+    console.log error
+    
+  ($ ".add_row_button").click ->
+    eg.addRow(eg.getRowCount()+1,{})
+    console.log window.fields

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+
+  def include_page_spesific_js
+    if FileTest.exists? "app/assets/javascripts/"+params[:controller]+"/"+params[:action]+".js.coffee.erb"
+      return '<script src="/assets/'+params[:controller]+'/'+params[:action]+'.js.coffee.erb" type="text/javascript"></script>'
+    end
+  end
+
 end

--- a/app/views/experiments/createSession.html.erb
+++ b/app/views/experiments/createSession.html.erb
@@ -22,8 +22,9 @@
 
 <div class="row">
   <div class="span4 center">
-    <a id="manual_entry" href="manualEntry"><img style="height: 200px;" src="/assets/manual.svg" /><br />
-    Manual Entry</a>
+    <%= link_to :controller => :experiments, :action => :manualEntry, :id => @experiment do %>
+      <img style="height: 200px;" src="/assets/manual.svg" /><br />Manual Entry
+    <% end %>
   </div>
   <div class="span4 center">
     <a id="upload_csv" href=""><img style="height: 200px;" src="/assets/upload.svg" /><br />

--- a/app/views/experiments/manualEntry.html.erb
+++ b/app/views/experiments/manualEntry.html.erb
@@ -1,29 +1,14 @@
 <script type="text/javascript">
-	$(document).ready(function(){
-		window.fields = JSON.parse('<%= raw @experiment.fields.to_json%>');
-		
-		var metadata = [];
-		for(var i = 0; i < window.fields.length; i++){
-			metadata.push({name: window.fields[i].name, label: window.fields[i].name, datatype:"string", editable: true});
-		}
-
-		var data = [];
-		var row = {};
-		for(var i = 0; i < window.fields.length; i++){
-			
-		}
-		data.push({id: 1, values: row});
-
-		editableGrid = new EditableGrid("DemoGridJsData");
-		editableGrid.load({"metadata": metadata, "data": data});
-		editableGrid.renderGrid("manual_entry", "testgrid table");
-	});
-
+//window.fields = JSON.parse('<%= raw @experiment.fields.to_json%>');
 </script>
+
+<% @experiment.fields.each do |field| %>
+  <>
+<% end %>
 
 <div class="row">
 	<div style="margin-bottom:20px" class="span12">			
-		<div id="manual_entry"></div>
+		<div id="manual_upload_table"></div>
 	</div>
 	<div style="margin-bottom:20px" class="span12">
 		<button class="add_row_button">Add Row</button>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
   <title>Rsense</title>
   <%= stylesheet_link_tag    "application", :media => "all" %>
   <%= javascript_include_tag "application" %>
+  <%= raw include_page_spesific_js %>
   <%= csrf_meta_tags %>
 </head>
 <body>


### PR DESCRIPTION
...n a rails friendly way. It seems more rails-y than the way rails deals with javascript. 

Basically rails automatically includes all javascript files in /app/assets/javascript in every page, if you want to make a controller#action spesific javascript file just create a new folder for the controller in /app/assets/javascript and name the .js.cofee.erb after the action you want.

For example I made a javascript file that only shows up when you hit the url /experiments/:id/manualEntry. The file is in /app/assets/javascript/experiments and is named manualEntry.js.coffee.erb
