### PR TITLE
Fixed different views of redactor content

### DIFF
--- a/app/views/experiments/show.html.erb
+++ b/app/views/experiments/show.html.erb
@@ -8,12 +8,12 @@
           <span style="font-size:2em"><%= experiment_edit_helper 'title', (@experiment.owner.id == @cur_user.try(:id)) %></span><br>
           <span class="info_label" style="font-size:1.1em">Owner:</span> 
           <%= link_to @experiment.owner.name, user_path(@experiment.owner) %><br>
-                                        <%if !@cloned_experiment.nil? %>
-                                                <span class="info_label" style="font-size:1.1em">Cloned From:</span>
-                                                <%=link_to @cloned_experiment.title, experiment_path(@cloned_experiment.id)%><br>
-                                        <%end%>
+            <%if !@cloned_experiment.nil? %>
+                    <span class="info_label" style="font-size:1.1em">Cloned From:</span>
+                    <%=link_to @cloned_experiment.title, experiment_path(@cloned_experiment.id)%><br>
+            <%end%>
           <span class="info_label" style="font-size:1.1em">Created:</span><%=time_ago_in_words(@experiment.created_at)%> ago <br>
-                                        <%=render "likes"%>
+          <%=render "likes"%>
         </div>
       </div>
       <div class="span8">

--- a/app/views/shared/_content.html.erb
+++ b/app/views/shared/_content.html.erb
@@ -5,36 +5,56 @@
 
 <div class="type_content" field='<%=field%>' type='<%=type%>'>
 
+  <!-- If there is content show the content -->
   <%if has_content %>
 
-  <div class="content_icontainer">
-    <%if can_edit%>
-    <a class="redactor_content_edit_link"><i class="icon-edit icon-white icon_content"></i></a>
-    <a href="/<%=type.pluralize%>/<%=row_id%>" class="redactor_content_save_link" style="display:none"><i class="icon-ok icon-white icon_content"></i></a>
-    <%end%>
-  </div>
-
-  <div class="redactor_content">
-    <%= raw content %>
-  </div>
-
-  <% else %>
-  
-  <div class="content_icontainer">
-    <a class="redactor_content_edit_link" style="display:none"><i class="icon-edit icon-white icon_content"></i></a>
-    <a href="/<%=type.pluralize%>/<%=row_id%>" class="redactor_content_save_link" style="display:none"><i class="icon-ok icon-white icon_content"></i></a>
-  </div>
-  
-  <div class="redactor_content" style="display:none">
-    <%= raw content %>
-  </div>
-  
-  <div class="well content_well" style="text-align:center">
-    <div class="add_content">
-      <a class="add_content_link"><img src="/assets/add_content.png" class="img-rounded"></a>
+    <div class="content_icontainer">
+      <%if can_edit%>
+      <a class="redactor_content_edit_link"><i class="icon-edit icon-white icon_content"></i></a>
+      <a href="/<%=type.pluralize%>/<%=row_id%>" class="redactor_content_save_link" style="display:none"><i class="icon-ok icon-white icon_content"></i></a>
+      <%end%>
     </div>
-  </div>
+
+    <div class="redactor_content">
+      <%= raw content %>
+    </div>
+    
+  <!-- If there is no content and you are the owner-->
+  <% elsif !has_content && can_edit %>
   
+    <div class="content_icontainer">
+      <a class="redactor_content_edit_link" style="display:none"><i class="icon-edit icon-white icon_content"></i></a>
+      <a href="/<%=type.pluralize%>/<%=row_id%>" class="redactor_content_save_link" style="display:none"><i class="icon-ok icon-white icon_content"></i></a>
+    </div>
+    
+    <div class="redactor_content" style="display:none">
+      <%= raw content %>
+    </div>
+    
+    <div class="well content_well" style="text-align:center">
+      <div class="add_content">
+        <a class="add_content_link"><img src="/assets/add_content.png" class="img-rounded"></a>
+      </div>
+    </div>
+    
+  <!-- If there is no content and you are NOT the owner or not logged in-->  
+  <% else %>
+    <div class="content_icontainer">
+     
+    </div>
+    
+    <div class="redactor_content" style="display:none">
+    </div>
+    
+    <div class="well content_well" style="text-align:center">
+      <div class="add_content">
+        <div class="no_content">
+          <!-- This needs to be a nice image of something -->
+          Content has not yet been added by the page's owner. 
+          <!--<a class="add_content_link"><img src="/assets/add_content.png" class="img-rounded"></a>-->
+        </div>
+      </div>
+    </div>
   <%end%>
 
 </div>


### PR DESCRIPTION
There are three cases for the redactor content windows now. 
1) There is content - display that content and allow owner to edit.
2) There is no content and you are the owner - plus sign is displayed
3) There is no content and you are not the owner - missing content message 
