### PR TITLE
Initial movement of create session functionality to experiments page

### DIFF
--- a/app/views/experiments/show.html.erb
+++ b/app/views/experiments/show.html.erb
@@ -45,6 +45,24 @@
                 <%end%>
             </table>
         <%end%>
+
+        <%=render layout: "shared/collapse", locals: {title: 'Create Session', width:'4'} do %>
+       
+            <div class="span1 center">
+                <%= link_to :controller => :experiments, :action => :manualEntry, :id => @experiment do %>
+                <img style="height: 75px;" src="/assets/manual.svg" /><br />Manual Entry
+                <% end %>
+            </div>
+            <div class="span1 center">
+                <a id="upload_csv" href=""><img style="height: 75px;" src="/assets/upload.svg" /><br />
+                Upload CSV</a>
+            </div>
+            <div class="span1 center">
+                <a id="google_doc" href=""><img style="height: 75px;" src="/assets/google.svg" /><br />
+                Google Doc</a>
+            </div>
+       
+        <% end %>
         
         <%=render layout: "shared/collapse", locals: {title: 'Sessions',width: '4'} do %>
             <table class="table">


### PR DESCRIPTION
There should not be a separate createSession page. The three options should be in a box on the experiments page as per mondays meeting
