### PR TITLE
visualization.rb, visualization.yml, and visualization_test.rb files have been renamed with correct spelling

### DIFF
--- a/test/fixtures/visualizations.yml
+++ b/test/fixtures/visualizations.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
+
+#Don't know what to put in content, data, and global fields
+
+visualization1:
+  title: VisualizationTitle1
+  user_id: 1
+  experiment_id: 1
+  content: MyText
+  data: MyText
+  globals: MyText
+
+visualization2:
+  title: VisualizationTitle2
+  user_id: 2
+  experiment_id: 2
+  content: MyText
+  data: MyText
+  globals: MyText

--- a/test/unit/visualization_test.rb
+++ b/test/unit/visualization_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class VisualizationTest < ActiveSupport::TestCase
+#  test "title" do
+#    assert_equal "VisualizationTitle1",
+  
+end


### PR DESCRIPTION
I renamed visualization.rb, visualization.yml, and visualization_test.rb files to all be spelled correctly.  The correct English spelling of visualization is with a "z," not "s."  These files have been renamed and any incorrect spelling errors in the files have been corrected, as well.
