### PR TITLE
Temporarily refreshing window on cancel upload

### DIFF
--- a/app/assets/javascripts/projects/show.js.coffee
+++ b/app/assets/javascripts/projects/show.js.coffee
@@ -115,7 +115,8 @@ $ ->
                                   </tr>"
 
       ($ "button.cancel_upload_button").click ->
-        ($ "#match_box").modal("hide")
+        location.reload()
+        #($ "#match_box").modal("hide")
 
       ($ "button.finished_button").click ->
 


### PR DESCRIPTION
Cancel upload on column matching caused page to be in a state where you could no longer upload a csv. This is temporarily fixed by refreshing the screen. 
