### PR TITLE
Fixed css rules for icons

### DIFF
--- a/app/assets/stylesheets/bootstrap_custom.css.scss
+++ b/app/assets/stylesheets/bootstrap_custom.css.scss
@@ -5,7 +5,7 @@ a:hover
   text-decoration: none;
 }
 
-i
+i[class*='icon-']
 {
   color: transparent;
   text-shadow: none;


### PR DESCRIPTION
A fix for issue #550, Bootstrap uses i tags for icons which is dumb
