### PR TITLE
Table no longer overflows.

### DIFF
--- a/app/views/data_sets/manualEntry.html.erb
+++ b/app/views/data_sets/manualEntry.html.erb
@@ -5,8 +5,8 @@
 <script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false"></script>
 
 <div class="row">
-  <div style="margin-bottom:20px" class="span12">
-    <table id="manualTable">
+  <div style="margin-bottom:20px" class="span12" style="">
+    <table id="manualTable" style="width:100%;overflow:auto;display:block">
       <thead>
         <tr>
         <% for field in @project.fields %>


### PR DESCRIPTION
A fix for issue #559. Added 100% width, overflow auto and display block the magic combo
