### PR TITLE
UI fix for button spacing

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -215,7 +215,7 @@
   <div class="clear"> </div>
   <div style="float:right;">
       <button id="save_doc" class="login_button btn btn-success">Save</button>
-      <button id="cancel_doc" class="cancel_login_button btn btn-danger" style="margin:15px 0px 0px 0px">Cancel</button>
+      <button id="cancel_doc" class="cancel_login_button btn btn-danger">Cancel</button>
   </div>
 </div>
 
@@ -229,7 +229,7 @@
 
   <div style="float:right;">
     <button class="finished_button btn btn-success"> Finished </button>
-    <button class="cancel_upload_button btn btn-danger" style="margin:15px 0px 0px 0px"> Cancel Upload </button>
+    <button class="cancel_upload_button btn btn-danger" style="margin:15px 6px 0px 0px"> Cancel Upload </button>
   </div>
 </div>
 
@@ -251,6 +251,6 @@
 
   <div style="float:right;">
     <button class="finished_button btn btn-success"> Finished </button>
-    <button class="cancel_upload_button btn btn-danger" style="margin:15px 0px 0px 0px"> Cancel Upload </button>
+    <button class="cancel_upload_button btn btn-danger" style="margin:15px 6px 0px 0px"> Cancel Upload </button>
   </div>
 </div>


### PR DESCRIPTION
Adding spacing between Cancel Upload and Finish buttons on the dialogue box for matching csv headers.

Removed styling for cancel_doc button because it was not necessary since it didn't need to override the styling defined for this class in the application.css.scss file.
