### PR TITLE
Added a fullscreen button to vizes

### DIFF
--- a/app/assets/javascripts/visualizations/visualizations.js.coffee
+++ b/app/assets/javascripts/visualizations/visualizations.js.coffee
@@ -1,13 +1,36 @@
 $ ->
   if namespace.controller is "visualizations" and namespace.action in ["displayVis","show"]
+    
+    ### Maximize event ###
+    fullscreen = () ->      
+      ($ '#title_bar').hide()  
+      ($ '#dataset_info').hide()
+      ($ '#title_row').hide() 
+      ($ '.footer').hide() 
+      ($ '.mainContent').data('padding',  ($ '.mainContent').parent().css('padding'))
+      ($ '.mainContent').parent().css('padding',"")
+
+    ### Minimize event ###
+    unfullscreen = () ->
+      ($ '#title_bar').show()
+      ($ '#dataset_info').show()
+      ($ '#title_row').show() 
+      ($ '.footer').show()
+      ($ '.mainContent').parent().css('padding',($ '.mainContent').data('padding'))
+    
+    ### What to do on min/max button click ###
     ($ '#fullscreen-viz').click ->
-      window.globals.fullscreen = true;
-      ($ '#title_bar').remove()
-      ($ '.footer').remove()
-      ($ '#dataset_info').remove()
-      ($ '#title_row').remove()
-      ($ '.mc-wide').removeClass("mainContent")
-      ($ '.mc-wide').removeClass("container")
-      ($ '.mc-wide').parents('div').replaceWith(($ '.mc-wide'))
+      icon = ($ this).find('i')
+      if (globals.fullscreen? and globals.fullscreen)
+        window.globals.fullscreen = false;
+        icon.removeClass('icon-resize-small')
+        icon.addClass('icon-resize-full')
+        unfullscreen()
+      else
+        window.globals.fullscreen = true;
+        icon.removeClass('icon-resize-full')
+        icon.addClass('icon-resize-small')
+        fullscreen() 
       ($ window).trigger('resize')
-      ($ this).remove()
+    
+    

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -111,7 +111,7 @@
       <% end %>
 
       <!-- Main Container -->
-      <div style="padding:50px 0px 70px 0px; margin:0; min-height:100%; <%= @layout_wide ? 'margin-right:40px;' : '' %>">
+      <div id="outer" style="padding:50px 0px 70px 0px; margin:0; min-height:100%; <%= @layout_wide ? 'margin-right:40px;' : '' %>">
         <div class="container mainContent <%= @layout_wide ? 'mc-wide' : '' %>" data-role="page">
           <%= yield %>
         </div>

--- a/app/views/visualizations/displayVis.html.erb
+++ b/app/views/visualizations/displayVis.html.erb
@@ -13,7 +13,7 @@
     <div id="viscontainer" style="height:500px;">
 
         <ul id='visTabList'>
-          <div class="pull-right"><button class="btn" id="fullscreen-viz"><i class="icon-fullscreen"></i></button></div>
+          <div class="pull-right"><button class="btn" id="fullscreen-viz" title="Maximize"><i class="icon-resize-full"></i></button></div>
         </ul><div class="clear"></div>
         
         <div id="map_canvas" class="vis_canvas"></div>

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -26,12 +26,12 @@
   </div>
 </div>
 
-<div style="margin: 0px 10px;">
+<div style="margin: 0px 10px;" >
 
   <div id="viscontainer" style="height:500px;">
 
     <ul id='visTabList'>
-       <div class="pull-right"><button class="btn" id="fullscreen-viz"><i class="icon-fullscreen"></i></button></div>
+       <div class="pull-right"><button class="btn" id="fullscreen-viz" title="Min/Max"><i class="icon-resize-full"></i></button></div>
     </ul>
     <div class="clear"></div>
     
@@ -51,7 +51,7 @@
 
   </div>
 
-  <div class="well" style="margin-top:10px">
+  <div class="well" style="margin-top:10px" id="dataset_info">
 
     <div class="full_width_edit" style="font-size:1.5em;"><%= visualization_edit_helper 'title', @visualization.owner.id == @cur_user.try(:id), make_link = false %></div>
     

--- a/lib/assets/javascripts/highvis/runtime.coffee
+++ b/lib/assets/javascripts/highvis/runtime.coffee
@@ -143,7 +143,7 @@ $ ->
     #Toggle control panel
     resizeVis = (toggleControls = true, aniLength = 600) ->
 
-        if globals? and globals.fullscreen?
+        if (globals.fullscreen? and globals.fullscreen)
           ($ "#viscontainer").height(($ window).height())
         else
           ($ "#viscontainer").height(($ window).height() - h)


### PR DESCRIPTION
One does not simply load a new page 

![one does not simply](https://f.cloud.github.com/assets/1268772/1298407/34da8b52-30f3-11e3-86bc-58056227c5b4.jpg)

Removes the surrounding page so that it can be fullscreen. Saves all changes that may have been made to the viz. 

A fix for #814
