### PR TITLE
Legend Tweaks

### DIFF
--- a/lib/assets/javascripts/highvis/baseVis.coffee
+++ b/lib/assets/javascripts/highvis/baseVis.coffee
@@ -299,6 +299,10 @@ $ ->
                     backgroundColor: 'white'
                     symbolWidth:60
                     itemWidth: 200
+                    useHTML: true
+                    itemStyle:
+                      width: 140
+                      cursor: 'default'
                 #loading: {}
                 plotOptions:
                     series:
@@ -382,13 +386,23 @@ $ ->
                     
             @chart.yAxis[0].setTitle title, false
         
+            @chart.addSeries
+              name: ' '
+              color: '#FFF'
+              width: 0
+        
             #Remove curent data
-            while @chart.series.length isnt 0
+            while @chart.series.length isnt 1
                 @chart.series[0].remove(false)
 
             #Draw legend
             for options in @buildLegendSeries()
               @chart.addSeries options, false
+              
+            foo = =>
+              if globals.fieldSelection.length isnt 0
+                @chart.series[0].remove(true)
+            setTimeout foo, 0
             
         ###
         Performs an update while displaying the loading text

--- a/lib/assets/javascripts/highvis/scatter.coffee
+++ b/lib/assets/javascripts/highvis/scatter.coffee
@@ -149,7 +149,7 @@ $ ->
                     legendIndex: fieldIndex
                     data: []
                     color: '#000'
-                    visible: if fieldIndex in globals.fieldSelection then true else false
+                    showInLegend: if fieldIndex in globals.fieldSelection then true else false
                     name: field.fieldName
 
                 switch


### PR DESCRIPTION
-Fixed most occurrences of legend labels spills out of their container. They now continue on to a second line.

-Made unselected fields not show up in the legend. This required a work around for a highcharts bug (reported) which causes a bit of animation flashing.
#866
