### PR TITLE
Fixing file upload bug

### DIFF
--- a/lib/file_uploader.rb
+++ b/lib/file_uploader.rb
@@ -55,7 +55,7 @@ class FileUploader
   
   ## Swap columns 
   def swap_columns(data_obj, project, matches) 
-    size = data_obj.first.length
+    size = data_obj.first[1].length
     data = []
     (0..size-1).each do |i|
       x = {}
@@ -70,7 +70,7 @@ class FileUploader
   
   def swap_without_matches(data_obj,project)
     data = []
-    size = data_obj.first.length
+    size = data_obj.first[1].length
 
     (0..size-1).each do |i|
       x = {}


### PR DESCRIPTION
Was trying to compute the size of the data contained in 
{["Temp", [1,2,3,4,5]],["Light",[6,7,8,9,10]]}
and was doing it wrong
