### PR TITLE
GPX parsing should be much better now.

### DIFF
--- a/lib/gpx_parser.rb
+++ b/lib/gpx_parser.rb
@@ -9,20 +9,47 @@ class GpxParser
     
     trkpts = doc.css("trkpt")
     
-    csv = "Timestamp,Name,Latitude,Longitude\n"
+    csv = "" 
+    headers = trkpts.first.attributes
+    
+    #Grab attributes from the first trkpt for headers
+    trkpts.first.attributes.each do |header|
+      csv += header[0] + ","
+    end
+    
+    #Grab contents from the first trkpt for headers
+    elements = []
+    trkpts.first.children.each do |test|
+      if test.class == Nokogiri::XML::Element
+        csv += test.name + ","
+        elements << test.name
+      end
+    end
+    csv = csv.chomp(",")
+    csv += "\n"
     
     trkpts.each do |pt|
-      csv += "#{pt.search('time').first.content},"
-      csv += "#{pt.search('name').first.content},"
-      csv += "#{pt.attribute('lat')},"
-      csv += "#{pt.attribute('lon')}\n"
+      line = ""
+      
+      #Grab headers out of attributes for each trkpt
+      headers.each do |h|
+        line += "#{pt.attribute(h[0])},"
+      end
+      
+      #Grab contents out of each trkpt  
+      elements.each do |e|
+        line += "#{pt.search(e).first.content},"
+      end
+      line = line.chomp(",")
+      line += "\n"
+      
+      #Add line to csv
+      csv += line
     end
     
     filename = write_temp_file(csv)
     
     roo = Roo::CSV.new(filename)
-
-#     cleanup_temp_file(filename)
 
     roo
     


### PR DESCRIPTION
The parser now looks at the first track point to get an idea of what values are inside,
no longer hardcoded to lat,lon,time,name

The following

``` xml
<trkpt lon="-71.72464708797634" lat="42.43801748380065">
  <ele>147.60000610351562</ele>
  <time>2013-09-28T17:34:13.000Z</time>
</trkpt>
```

would yeild a csv that looks like 

```
lon,lat,ele,time
-71.72464708797634,42.43801748380065,147.60000610351562,2013-09-28T17:34:13.000Z
```
