### PR TITLE
Table Vis displays blank string instead of null

### DIFF
--- a/lib/assets/javascripts/highvis/table.coffee
+++ b/lib/assets/javascripts/highvis/table.coffee
@@ -33,7 +33,7 @@ $ ->
         constructor: (@canvas) -> 
 
         nullFormatter = (cellvalue, options, rowObject) ->
-            cellvalue = "" if cellvalue is undefined or cellvalue.toLowerCase() is 'null'
+            cellvalue = "" if isNaN(cellvalue)
             cellvalue;
 
         start: ->


### PR DESCRIPTION
Only on number type fields, shouldn't effect a text field where the user has actually typed "null"
#1220
