### PR TITLE
Fixing CK

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,23 @@ require File.expand_path('../config/application', __FILE__)
 
 Rsense::Application.load_tasks
 
+namespace :ckeditor do
+  desc 'Create nondigest versions of some ckeditor assets (e.g. moono skin png)'
+  task :create_nondigest_assets do
+    fingerprint = /\-[0-9a-f]{32}\./
+    for file in Dir['public/assets/ckeditor/contents-*.css', 'public/assets/ckeditor/skins/moono/*.png']
+      next unless file =~ fingerprint
+      nondigest = file.sub fingerprint, '.' 
+      FileUtils.cp file, nondigest, verbose: true
+    end
+  end
+end
+
+# auto run ckeditor:create_nondigest_assets after assets:precompile
+Rake::Task['assets:precompile'].enhance do
+  Rake::Task['ckeditor:create_nondigest_assets'].invoke
+end
+
 namespace :db do
   task :preprep do
     if ENV['DB']


### PR DESCRIPTION
We need to copy over icon files explicitly after the fingerprinted versions are created.
#1287
