### PR TITLE
Fixing ID types

### DIFF
--- a/db/migrate/20140129155906_fix_decimal_wierdness.rb
+++ b/db/migrate/20140129155906_fix_decimal_wierdness.rb
@@ -1,0 +1,11 @@
+class FixDecimalWierdness < ActiveRecord::Migration
+  def up
+    change_column :tutorials, :user_id, :integer
+    change_column :media_objects, :visualization_id, :integer
+  end
+  
+  def down
+    change_column :tutorials, :user_id, :decimal
+    change_column :media_objects, :visualization_id, :decimal
+  end
+end


### PR DESCRIPTION
Somehow some ids got changed to decimal in our schema. 
Fixing:
 tutorials -> user_id
 media_objects -> visualization_id
