### PR TITLE
This branch addresses issue #1316.  The empty sets of parentheses append...

### DIFF
--- a/app/views/data_sets/manualEntry.html.erb
+++ b/app/views/data_sets/manualEntry.html.erb
@@ -28,7 +28,7 @@
           <tr>
           <% for field in @project.fields %>
             <th data-field-type="<%= get_field_name(field.field_type) %>" data-field-id="<%= field.id %>" data-field-restrictions="<%= field.restrictions %>" data-field-name="<%= field.name %>" ><%= field.name %>
-            <% if field.unit != "" %>
+            <% if field.unit != "" and !field.unit.nil? %>
               (<%=field.unit%>)
             <% end %></th>
           <% end %>


### PR DESCRIPTION
...ed to the data type no longer appear on any view in which a data type has no unit.  Yay!

Apparently, git truncated by commit message.  This branch addresses #1316.  The empty set of parentheses after a data type that denotes the unit of the data type will no longer appear if the unit is null.  
