### PR TITLE
Fixing date parse on visualize

### DIFF
--- a/lib/assets/javascripts/dateParse.coffee
+++ b/lib/assets/javascripts/dateParse.coffee
@@ -10,7 +10,7 @@ $ ->
     Also supports giving a year as an integer.
   ###
   helpers.parseTimestamp = (str) ->
-    if str is null
+    if (str is null)  or (str is "")
       return null
     else if not isNaN(Number str)
       year = Number str


### PR DESCRIPTION
Dates filled in with empty string were getting parsed incorrectly. They should be better now.
Towards #1305
