### PR TITLE
Addresses issue #1313.  The "What's New" box will no longer overflow wit...

### DIFF
--- a/app/assets/stylesheets/home.css.scss
+++ b/app/assets/stylesheets/home.css.scss
@@ -19,6 +19,13 @@
   }
 }
 
+.news_description
+{
+  height: 98px ; 
+  word-wrap: break-word ;
+  overflow: hidden  
+}
+
 .news_featured_image
 {
   float:left;

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -68,7 +68,7 @@
               <div style="padding:7px;height:184px">
                 <span class="item_title"><%= n.title %></span><br/>
                 <span style="font-size:0.8em">Written on <%=n.created_at.strftime("%B %d, %Y")%></span><br/><br/>
-                <div style="height: 98px ; word-wrap: break-word ; overflow: hidden"><%= n.summary%><br/> </div>
+                <div class="news_description"><%= n.summary%><br/> </div>
                 <div style ="margin-top: 5px"> <%= link_to "Read More", news_path(n) %> </div>
               </div>
             </div>


### PR DESCRIPTION
...h text, regardless of the length of any word or the summary.  The read-more button will also no longer move out of the box.
