### PR TITLE
Adding a call to API for users

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module V1
+    class UsersController < ActionController::UsersController
+      skip_before_filter :authorize
+      before_filter :set_user
+
+      def my_info
+        gravatar = Gravatar.new.url(@cur_user,80)
+        
+        respond_to do |format|
+          format.json {render json: {gravatar: gravatar, username:@cur_user.name},status: :ok}
+        end
+        
+      end
+      
+    end
+  end
+end

--- a/app/views/home/api_v1.html.erb
+++ b/app/views/home/api_v1.html.erb
@@ -468,6 +468,34 @@
   </div>
 </div>
 
+<div class="row">
+  <div class="col-md-12">
+    <table class="table table-bordered api">
+      <tr>
+        <td class="GET def">GET</td>
+        <td class="method"> Users </td>
+        <td class="code">/api/v1/users/myInfo</td>
+        <td class="args">email(req),password(req)</td>
+      </tr>
+      <tr class="more" style="">
+        <td colspan="4">
+          <b>Response Codes</b>
+          <li>Success: 200 Ok</li>
+          <li>Fail: 401 Unauthorized</li>
+          <b>Response</b>
+          <pre>
+    {
+      gravatar: "gravatar url(string)"
+      name: "display name (string)"
+    }
+          </pre>
+          <b>Notes</b>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+
 <hr/>
 <div class="row">
   <p>This API runs through automated testing every time someone makes a change to the website. The following tests have been written</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,7 @@ Rsense::Application.routes.draw do
       post '/projects/:id/jsonDataUpload' => "data_sets#jsonDataUpload"
       post '/media_objects' => "media_objects#saveMedia"
       get  '/media_objects/:id' => "media_objects#show"
+      get '/users/myInfo' => "users#my_info"
       resources :projects, :only => [:show,:index,:create]
       resources :fields, :only => [:create,:show]
       resources :visualizations, :only => [:show]

--- a/test/integration/api_v1_test.rb
+++ b/test/integration/api_v1_test.rb
@@ -455,6 +455,24 @@ class ApiV1Test < ActionDispatch::IntegrationTest
 
   end
   
+  test "get user info" do
+    get '/api/v1/users/myInfo',
+      {
+        email: 'kcarcia@cs.uml.edu',
+        password: '12345'
+      }
+    assert_response :success
+  end
+  
+  test "fail get user info" do
+    get '/api/v1/users/myInfo',
+      {
+        email: 'kcarcia@cs.uml.edu',
+        password: '1234'
+      }
+    assert_response :unauthorized
+  end
+  
   private
   def parse (x)
     JSON.parse(x.body)


### PR DESCRIPTION
/api/v1/users/myInfo is now a call you can use. 

It returns
{
   gravatar: 'url to gravatar'
   name: 'display name'
}

requires email and password.
