### PR TITLE
Removed ability to upload images to WYSIWYG editor

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -17,7 +17,7 @@ CKEDITOR.editorConfig = function( config ) {
     { name: 'clipboard', groups: [ 'undo' ], items: [ 'Undo', 'Redo' ] },
     { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ], items: [ 'Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', '-', 'RemoveFormat' ] },
     { name: 'paragraph', groups: [ 'list', 'align'], items: [ 'NumberedList', 'BulletedList', '-', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock'] },
-    { name: 'upload', groups: [ 'image' ], items: [ 'Image' ] },
+    //{ name: 'upload', groups: [ 'image' ], items: [ 'Image' ] },
     '/',
     { name: 'styles', items: [ 'Format', 'Font', 'FontSize' ] },
     { name: 'colors', items: [ 'TextColor', 'BGColor' ] },


### PR DESCRIPTION
Addresses issue #1446, at least temporarily, primarily to address the following issue in Firefox that I found after posting the issue.
![oh_no](https://f.cloud.github.com/assets/6451941/2501181/8951e308-b369-11e3-897e-665d8a07d395.png)
