### PR TITLE
Usability changes to Contrib Key Sorting Feature

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -102,19 +102,36 @@
                           <a role="menuitem" href="javascript:void(0);" id="check_mine"><i class="fa fa-user"></i> Mine</a>
                         </li>
                     <% end %>
-                    <% @sort_keys = []%>
+                    <% @sort_keys = {}%>
+                    <% @dataset_keys = []%>
+                    <% @symbol_hash = {} %>
                     <% if can_edit? (@project) %>
                       <% @data_sets.each do |d| %>
-                        <% if !d.key.nil? and !(@sort_keys.include? d.key) and d.key != "" %>
-                          <%  @sort_keys.append d.key %>
+                        <% if !d.key.nil? and d.key != "" %>
+                          <% if @dataset_keys.include? d.key %>
+                            <% @dataset_keys.delete d.key %>
+                            <% @dataset_keys = @dataset_keys.select {|x| !x.nil?} %>
+                            <% @dataset_keys.append d.key %>
+                          <% else %>
+                            <%  @dataset_keys.append d.key %>
+                          <% end %>
                         <%end%>
-                      <% end %>
-                      <% for ele in 0...@sort_keys.length do %>
+                      <% end %> 
+                      <% label = 'A' %>
+                      <% for ele in 0...@dataset_keys.size %>
+                        <% @symbol_hash[@dataset_keys[ele]] = label %>
+                        <% label = label.next %>
+                      <% end %> 
+                      
+                      <% for ele in 0...@dataset_keys.length do %>
                         <li role="presentation">
-                          <a role="menuitem" m-title="<%= @sort_keys[@sort_keys.length - ele - 1] %>" href="javascript:void(0);" class="check_id"><i class="fa fa-square-o"></i> <%= @sort_keys[@sort_keys.length - ele - 1] %> </a> 
+                          <a role="menuitem" m-title="<%= @dataset_keys[@dataset_keys.length - ele - 1] %>" href="javascript:void(0);" class="check_id"><i class="fa fa-square-o"></i> <%= @dataset_keys[@dataset_keys.length - ele - 1]  + ' (' + @symbol_hash[@dataset_keys[ele]] + ')' %> </a> 
                         </li>
+                      
+                        
                       <% end %>
                     <%end%>
+                   
                   </ul>
             </div>  
           </div>
@@ -122,22 +139,23 @@
           <table id="dataset_table">
             <tbody>
               <% unless @project.contrib_keys.nil? %>
-                <% used_keys = [] %> 
-                <% next_char = 'A' %>
-                <% @sort_keys.size.times do %> 
-                  <% used_keys.unshift next_char %>
-                  <% next_char.next %>
-                <%end %> 
+                <% used_keys = {} %> 
+              <% end %>
+              <% counter = 0 %>
+              <% key_label = 'A' %>
+              <% for e in 0...@dataset_keys.length%>
+                <% used_keys[@dataset_keys[@dataset_keys.length - 1 - e ] ] = key_label %> 
+                <%key_label = key_label.next%>
               <% end %>
               <% @data_sets.each do |s| %>
                 <tr class="<%= cycle('feed-even', 'feed-odd')%> dataset" style="position:relative">
                 <% if( not (s.key.nil?) and can_edit?( @project) )%>
                   <% if used_keys[s.key].nil? %> 
-                    <% used_keys[s.key] = next_char %>
-                    <% next_char = next_char.next %>             
-                <% end %>
+                    <% used_keys[s.key] = @dataset_keys[counter] %>
+                    <% counter = counter + 1 %>
+                  <% end %>
                   <td class="key_icon">
-                    <div class="key" title="<%= s.key %>"> <%= image_tag("Key.png", :size => "32x32") %> <a class = "key-letter-id"> <%= used_keys[s.key]%></a></div> 
+                    <div class="key" title="<%= s.key %>"> <%= image_tag("Key.png", :size => "32x32") %> <a class = "key-letter-id"> <%= used_keys[s.key] %></a></div> 
                   </td>
                 <% else %>
                   <td class="gravatar">


### PR DESCRIPTION
@kcarcia, this addresses the issues we discussed today.  The drop down menu now has the same letter as the letter chosen to overlay the key, the first label (A) is assigned to the contributor key that was first used to upload a data set in order to preserve ordering/not reorder everything if a new key is added.  Did a final round of usability testing and everything (thankfully) looked as though it was behaving in the way we intended.
