### PR TITLE
Fixed undefined error in safari with jquery selector

### DIFF
--- a/lib/assets/javascripts/highvis/timeline.coffee
+++ b/lib/assets/javascripts/highvis/timeline.coffee
@@ -98,9 +98,9 @@ $ ->
       ###
       drawRegressionControls: () ->
         super()
-        #For now we are supporting only linear and quadratic on timelines
+        # For now we are supporting only linear and quadratic on timelines
         for child, index in ($ "#regressionSelector").children() when index >= 2
-          child.remove()
+          ($ child).remove()
 
       ###
       Overwrite xAxis controls to only allow time fields


### PR DESCRIPTION
There is no bug associated with this, but the error was that timelines in safari were no loading the first time.

Steps to reproduce on safari:
1. Find a data set that has time data.
2. Switch to timeline.
3. If it's blank, that's bad. Else, we're good.
