### PR TITLE
Map Markers Not Connected by Default

### DIFF
--- a/lib/assets/javascripts/highvis/map.coffee
+++ b/lib/assets/javascripts/highvis/map.coffee
@@ -43,7 +43,7 @@ $ ->
         @HEATMAP_MARKERS = -1
 
         @visibleMarkers = 1
-        @visibleLines = 1
+        @visibleLines = 0
         @visibleClusters = if data.dataPoints.length > 100 then 1 else 0
         @heatmapSelection = @HEATMAP_NONE
 


### PR DESCRIPTION
Sets visible lines to 0 so that the connect clusters is not checked by default.
#1473
