### PR TITLE
Added Row numbers back if data failed validation

### DIFF
--- a/lib/assets/javascripts/editTable.js.coffee
+++ b/lib/assets/javascripts/editTable.js.coffee
@@ -390,7 +390,7 @@ $ ->
             ($ tab).find('tbody').find('tr').each (i,j) ->
               ($ j).prepend("<td style='width:10%;text-align:center'>" + renumber + " </td> ")
               renumber += 1
-            alert "You must enter at least one row of data."             
+            alert "You must enter at least one row of data."
             return false
 
           # Check that there is at least one value
@@ -402,7 +402,7 @@ $ ->
             ($ tab).find('thead').find('tr').prepend("<th style='width:10%'> Row Number </th>")
             ($ tab).find('tbody').find('tr').each (i,j) ->
               ($ j).prepend("<td style='width:10%;text-align:center'>" + renumber + " </td> ")
-              renumber += 1            
+              renumber += 1
             alert "You must enter at least one item of data."
             return false
 


### PR DESCRIPTION
I was playing around with my row numbering feature, and found a bug that occurred when the data failed to validate (the first row is always removed, so subsequent submissions deleted data.  In the cases in which validation failed, I added the row information back.
