### PR TITLE
Row no longer disappear from manual table

### DIFF
--- a/lib/assets/javascripts/editTable.js.coffee
+++ b/lib/assets/javascripts/editTable.js.coffee
@@ -418,7 +418,8 @@ $ ->
             return false
 
           if ($ 'input').hasClass 'invalid'
-            ($ '#manualTable').find('thead').find('tr').prepend("<th style='width:10%;text-align:center'> Row Number </th>")
+            ($ '#manualTable').find('thead').find('tr').prepend(
+              "<th style='width:10%;text-align:center'> Row Number </th>")
             rowNum = 1
             ($ '#manualTable').find('tbody').find('tr').each (i,j) ->
               ($ j).prepend("<td style='width:10%;text-align:center'>" + rowNum + "</td>")


### PR DESCRIPTION
Addresses the bug discovered during testing today, where attempting to save invalid data caused the first column of the manual entry table to get truncated.  Bug caused as a result of #756
