### PR TITLE
Fixing missing put variable documentation (api v1)

### DIFF
--- a/app/views/home/api_v1.html.erb
+++ b/app/views/home/api_v1.html.erb
@@ -293,6 +293,7 @@
           <b>Data</b>
           <pre>
   {
+    "title" => "Title for the dataset (string)"
     "contribution_key" => "key created by project owner (string)",
     "contributor_name" => (string),
     "data" =>


### PR DESCRIPTION
Jsondataupload with contributor key was missing a put variable in the documentation. 

The api was correct. 
#1505
