### PR TITLE
Exporting

### DIFF
--- a/app/assets/javascripts/projects/show.js.coffee
+++ b/app/assets/javascripts/projects/show.js.coffee
@@ -112,6 +112,16 @@ $ ->
       else
         window.location = ($ this).attr("href") + ds_list
 
+    ($ '#export_concatenated_button').click (e) ->
+      ($ '#export_modal').modal('hide')
+      targets = ($ document).find(".dataset .ds_selector input:checked")
+      ds_list = (get_ds_id t for t in targets)
+            
+      if ds_list.length is 0
+        alert "No data sets selected for Export. Select at least 1 and try again."
+      else
+        window.location = ($ this).attr("href") + ds_list
+
     # get the session number for viewing vises
     get_ds_id = (t) ->
       ds_id = ($ t).attr 'id'

--- a/app/controllers/data_sets_controller.rb
+++ b/app/controllers/data_sets_controller.rb
@@ -194,6 +194,18 @@ class DataSetsController < ApplicationController
   end
 
   # GET /projects/1/export
+  def export_concatenated
+    require 'uri'
+    require 'tempfile'
+
+    csv = Project.find(params[:id]).export_concatenated(params[:datasets])
+
+    respond_to do |format|
+      format.html { send_file csv, type: 'file/text', x_sendfile: true }
+    end
+  end
+
+  # GET /projects/1/export
   def export
     require 'uri'
     require 'tempfile'

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -94,6 +94,17 @@ class DataSet < ActiveRecord::Base
     fname
   end
 
+  def data_as_csv_string
+    project = Project.find(project_id)
+    fields = project.fields
+    dstring = ''
+    data.each do |datapoint|
+      dstring += (fields.map { |f| datapoint["#{f.id}"] }.join(',') + "\n")
+    end
+
+    dstring
+  end
+
   def self.get_next_name(project)
     highest = 0
     base = 'Dataset #'

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -149,6 +149,28 @@ class Project < ActiveRecord::Base
     h
   end
 
+  def export_concatenated(datasets)
+    require 'fileutils'
+    random_hex = SecureRandom.hex
+    folder_name = title.parameterize
+    tmpdir = "/tmp/rsense/#{random_hex}/#{folder_name}"
+
+    begin
+      FileUtils.mkdir_p(tmpdir)
+      tmp_file = File.new("#{tmpdir}/#{title.gsub(' ', '_')}_selected_data_sets.csv", 'w+')
+      tmp_file.write(fields.map { |f| f.name }.join(',') + "\n")
+      datasets.split(',').each do |d|
+        dataset = DataSet.find(d.to_i)
+        tmp_file.write(dataset.data_as_csv_string)
+      end
+      tmp_file.close
+      csv_file = "/tmp/rsense/#{random_hex}/#{folder_name}/#{title.gsub(' ', '_')}_selected_data_sets.csv"
+    rescue
+      raise 'Failed to export'
+    end
+    csv_file
+  end
+
   def export_data_sets(datasets)
     require 'fileutils'
     random_hex = SecureRandom.hex

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -371,7 +371,7 @@
 	    <button type="button" class="btn btn-default col-md-12" style="margin: 10px;" id="export_individual_button" href="/projects/<%=@project.id%>/export/data_sets/">Individual Files</button>
 	  </div>
 	  <div class="col-md-4 col-md-offset-1">
-	    <button type="button" class="btn btn-default col-md-12" style="margin: 10px;" id="export_individual_button" href="/projects/<%=@project.id%>/export/data_sets/">Single File</button>
+	    <button type="button" class="btn btn-default col-md-12" style="margin: 10px;" id="export_concatenated_button" href="/projects/<%=@project.id%>/export_concatenated/data_sets/">Single File</button>
 	  </div>
 	</div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rsense::Application.routes.draw do
   get '/projects/:id/manualEntry' => 'data_sets#manualEntry'
   post '/projects/:id/jsonDataUpload' => 'data_sets#jsonDataUpload'
   get '/projects/:id/export/data_sets/*datasets' => 'data_sets#export'
+  get '/projects/:id/export_concatenated/data_sets/*datasets' => 'data_sets#export_concatenated'
   get '/projects/:id/export' => 'data_sets#export'
 
   get '/data_sets/:id/edit' => 'data_sets#edit'

--- a/test/functional/data_sets_controller_test.rb
+++ b/test/functional/data_sets_controller_test.rb
@@ -129,6 +129,12 @@ class DataSetsControllerTest < ActionController::TestCase
     assert(@response['Content-Type'] == 'file/zip')
   end
 
+  test 'should get data as csv string' do
+    get :export_concatenated, { id: @proj.id, datasets: @tgd.id.to_s },  user_id: @kate
+    assert response.body.include?('cookie,cake,pie'), 'Response was not correct string'
+    assert_response :success
+  end
+
   test 'should upload CSV' do
     csv_path = Rails.root.join('test', 'CSVs', 'dinner.csv')
     file = Rack::Test::UploadedFile.new(csv_path, 'text/csv')


### PR DESCRIPTION
As of USASEF we noted the need to be able to export data sets as 
1) Individual files (current standard)
2) A Single concatenated file

Now, when you click the export button a modal appears that asks which you would like to do. Individual files export as a zip, concatenated exports as a csv.

Also fixed styling of a few buttons on the experiment show page. 

TESTERS: Please try exporting a project with multiple data sets both ways and verify that this works. 
