### PR TITLE
Auto sorting for Bar chart now works on other browsers

### DIFF
--- a/lib/assets/javascripts/highvis/bar.coffee
+++ b/lib/assets/javascripts/highvis/bar.coffee
@@ -115,7 +115,7 @@ $ ->
               ($ j).removeAttr('selected')
             ($ '#ui-accordion-toolControl-panel-0').find('.inner_control_div').find('option').each (i,j) ->
               if ($ j).attr('value') == sorter
-                ($ j).attr('selected',true)
+                ($ j).prop('selected',true)
             if( !autoSorted )
               autoSorted = 1
               ($ '.sortField').change()


### PR DESCRIPTION
Addresses the problems we found with issue #1479 (auto-sorting bar chart based upon Y-axis values) that were discovered during testing the Friday before finals
