### PR TITLE
Keys no longer persistent across sessions

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,6 +17,8 @@ class SessionsController < ApplicationController
   end
 
   def create
+    session[:key] = nil
+    session[:contrib_access] = nil
     login_email = params[:email].downcase
 
     @user = User.where('lower(email) = ?', login_email).first
@@ -41,6 +43,8 @@ class SessionsController < ApplicationController
 
   def destroy
     session[:user_id] = nil
+    session[:key] = nil
+    session[:contrib_access] = nil
     respond_to do |format|
       format.html { redirect_to :back, notice: 'Logged out' }
       format.json { render json: {}, status: :ok }


### PR DESCRIPTION
Keys will no longer persist across sessions, which also fixes logged in users being able to contribute data to a locked project if a key was entered before the session began.  Addresses issue #1566
