### PR TITLE
Added title of project to tab

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -122,7 +122,12 @@ module ApplicationHelper
   end
 
   def render_title
-    "iSENSE - #{@namespace[:controller].capitalize}"
+    if @namespace[:controller] != "projects"
+      "iSENSE - #{@namespace[:controller].capitalize}"
+    else
+      title_proj = Project.find(params[:id]).name
+      "iSENSE - #{title_proj}"
+    end
   end
 
   def is_admin?


### PR DESCRIPTION
Fixes #1593 .

Adds the name of the project to the browser tab if the page is a project.  Otherwise, it does nothing.
