### PR TITLE
Fix title fix

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -122,7 +122,7 @@ module ApplicationHelper
   end
 
   def render_title
-    if @namespace[:controller] != 'projects' or params[:id].is_a? NilClass
+    if @namespace[:controller] != 'projects' or !params.key?(:id)
       "iSENSE - #{@namespace[:controller].capitalize}"
     else
       title_proj = Project.find(params[:id]).name


### PR DESCRIPTION
Fixes #1593

Adds the project title to the tab/title bar when on a project page, but not when on the project index or any other non-project page.
