### PR TITLE
API Documentation Boxes Expand Properly

### DIFF
--- a/app/assets/javascripts/api.js.coffee
+++ b/app/assets/javascripts/api.js.coffee
@@ -2,7 +2,7 @@
 
 IS.onReady 'home/api_v1', ->
 
-	# toggle the visibility of the expanding boxes labeled either 'GET' or 'POST'
+  # toggle the visibility of the expanding boxes labeled either 'GET' or 'POST'
   ($ '.def').click ->
     expand = ($ this).parent().parent().children '.more'
     expand.toggle()


### PR DESCRIPTION
#1597

Documentation boxes used to expand on click - this behavior stopped some time a couple of weeks ago.  This is now fixed and the boxes properly expand and hide themselves on click.  I have not figured out why they stopped working in the first place.  I also couldn't locate a file that had any CoffeeScript pertaining to this, so I added api.js.coffee with the eight line fix.
