### PR TITLE
Summary vis rounding!

### DIFF
--- a/app/assets/javascripts/projects/show.js.coffee
+++ b/app/assets/javascripts/projects/show.js.coffee
@@ -172,7 +172,7 @@ IS.onReady "projects/show", ->
         dataType: "json"
         beforeSend: ->
           ($ '#ajax-status').html "deleting data set: #{ p_id }"
-        success: =>
+        success: ->
           ($ '#ajax-status').html "deleted data set: #{ p_id }"
           recolored = false
           tbody = row.parents('tbody')
@@ -180,7 +180,7 @@ IS.onReady "projects/show", ->
             row.remove()
             tbody.recolor_rows(recolored)
             recolored = true
-        error: (msg) =>
+        error: (msg) ->
           ($ '#ajax-status').html "error deleting data set: #{ p_id }"
           response = $.parseJSON msg['responseText']
           error_message = response.errors.join "</p><p>"
@@ -205,7 +205,7 @@ IS.onReady "projects/show", ->
               url: url
               type: 'DELETE'
               dataType: "json"
-              success: =>
+              success: ->
                 ($ '.error_bind').button 'reset'
                 ($ '.alert').alert 'close'
                 ($ '#ajax-status').html "deleted data set: #{ p_id }"

--- a/lib/assets/javascripts/highvis/summary.coffee
+++ b/lib/assets/javascripts/highvis/summary.coffee
@@ -62,37 +62,49 @@ $ ->
                   <div class="col-md-4">
                     <div class='panel panel-default'>
                       <div class='panel-heading'>Mean</div>
-                      <div class='panel-body'>#{if analysis[0].mean? then analysis[0].mean else noData}</div>
+                      <div class='panel-body'>
+                        #{if analysis[0].mean? then roundOutput(analysis[0].mean, 3) else noData}
+                      </div>
                     </div>
                   </div>
                   <div class="col-md-4">
                     <div class='panel panel-default'>
                       <div class='panel-heading'>Max</div>
-                      <div class='panel-body'>#{if analysis[0].max? then analysis[0].max else noData}</div>
+                      <div class='panel-body'>
+                        #{if analysis[0].max? then roundOutput(analysis[0].max, 3) else noData}
+                      </div>
                     </div>
                   </div>
                   <div class="col-md-4">
                     <div class='panel panel-default'>
                       <div class='panel-heading'>Total</div>
-                      <div class='panel-body'>#{if analysis[0].total? then analysis[0].total else noData}</div>
+                      <div class='panel-body'>
+                        #{if analysis[0].total? then roundOutput(analysis[0].total, 3) else noData}
+                      </div>
                     </div>
                   </div>
                   <div class="col-md-4">
                     <div class='panel panel-default'>
                       <div class='panel-heading'>Median</div>
-                      <div class='panel-body'>#{if analysis[0].median? then analysis[0].median else noData}</div>
+                      <div class='panel-body'>
+                        #{if analysis[0].median? then roundOutput(analysis[0].median, 3) else noData}
+                      </div>
                     </div>
                   </div>
                   <div class="col-md-4">
                     <div class='panel panel-default'>
                       <div class='panel-heading'>Min</div>
-                      <div class='panel-body'>#{if analysis[0].min? then analysis[0].min else noData}</div>
+                      <div class='panel-body'>
+                        #{if analysis[0].min? then roundOutput(analysis[0].min, 3) else noData}
+                      </div>
                     </div>
                   </div>
                   <div class="col-md-4">
                     <div class='panel panel-default'>
                       <div class='panel-heading'>Data Point Count</div>
-                      <div class='panel-body'>#{if analysis[0].count? then analysis[0].count else noData}</div>
+                      <div class='panel-body'>
+                        #{if analysis[0].count? then roundOutput(analysis[0].count, 3) else noData}
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -107,6 +119,8 @@ $ ->
         super()
         @drawGroupControls(true, true)
         @drawYAxisControls(true)
-
+        
+      #Rounds arg to "digits" number of decimal places only if necessary
+      roundOutput = (arg, digits) ->
+        +(Math.round(arg + "e+#{digits}")  + "e-#{digits}")
       globals.summary = new Summary "summary_canvas"
-


### PR DESCRIPTION
Displayed values on summary vis can now be configured to round to an arbitrary number of decimal places.  I set it to three for all fields, although this can be easily changed if desired.  Values are only rounded to the desired number of decimal places if the value has more than that number of decimal places.  That is, rounding the number 1 to three decimal places will display 1, while 1.1234 will display 1.123.

Addresses issue #1559
