### PR TITLE
Show the random seed before tests run

### DIFF
--- a/lib/seed_reporter.rb
+++ b/lib/seed_reporter.rb
@@ -1,7 +1,6 @@
 module Minitest
   module Reporters
     class SeedReporter < BaseReporter
-
       def initialize(options = {})
         super
         @options = options
@@ -32,7 +31,6 @@ module Minitest
       def report
         super
       end
-
     end
   end
 end


### PR DESCRIPTION
Addresses a problem with turn's replacement.

Now that Minitest randomizes the order in which tests are run, knowing the seed used is super important. The current reporters for Minitest hide this, so I added it back in.

Just pretend that all of the code in the last pull request is actually in this one and that something that failed Rubocop didn't get merged into master.
