### PR TITLE
Fix links to datasets when the URL to the project ends in a slash

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -174,7 +174,7 @@
                   </td>
                <% end %>
                   <td style="max-width:60px"><div class="truncate"><%= link_to s.owner.name, user_path(s.owner) %></div></td>
-                  <td style="max-width:200px"><div class="truncate" title="Created <%=s.created_at.strftime("%B %d, %Y")%>"><%= link_to s.title, "#{params[:id]}/data_sets/#{s.id}" %></div></td>
+                  <td style="max-width:200px"><div class="truncate" title="Created <%=s.created_at.strftime("%B %d, %Y")%>"><%= link_to s.title, "/projects/#{params[:id]}/data_sets/#{s.id}" %></div></td>
                  <td>
                  <div class="controls" style="">                  
                       <% if can_edit? s %>


### PR DESCRIPTION
Addresses #1680

This fixes that.  Long story short, Rails routes /projects/1 and /projects/1/ the exact same way.  However, relative paths in browsers work differently - a relative path without a forward slash inserts itself after the last forward slash, while a relative path with a forward slash inserts itself after the first one.  The links previously did the former, now they do the latter.
