### PR TITLE
Make news preview boxes more informative

### DIFF
--- a/app/assets/stylesheets/news.css.scss
+++ b/app/assets/stylesheets/news.css.scss
@@ -7,29 +7,40 @@
 	.item-image {
 		margin-right: 5px;
 	}
-	.news_page_content {
-		height: 110px;
-		overflow-y: hidden;
-		position: relative;
-	}
-	.news_page_date {
-		font-size:0.8em;
-		margin-bottom: 20px;
-	}
-	.news_page_link {
-		position: absolute;
-		bottom: 0;
-		padding-top: 40px;
-		text-align: center;
-		width: 100%;
-		background: linear-gradient(rgba(221, 221, 211, 0),
-			rgba(221, 221, 221, 1) 65%,
-			rgba(221, 221, 221, 1));
-	}
-	.news_page_subtitle {
-	}
-	.news_page_title {
-		white-space: nowrap;
-		font-size: 20px;
+
+	.item-desc {
+		margin-left: 5px;
+
+		.news_page_content {
+			height: 110px;
+			overflow-y: hidden;
+			position: relative;
+		}
+		.news_page_date {
+			font-size:0.8em;
+			margin-bottom: 20px;
+		}
+		.new_page_image {
+
+		}
+		.news_page_link {
+			position: absolute;
+			bottom: 0;
+			padding-top: 40px;
+			text-align: center;
+			width: 100%;
+			background: linear-gradient(rgba(221, 221, 211, 0),
+				rgba(221, 221, 221, 1) 65%,
+				rgba(221, 221, 221, 1));
+		}
+		.news_page_subtitle {
+			height: 16px;
+			white-space: nowrap;
+			overflow: hidden;
+		}
+		.news_page_title {
+			white-space: nowrap;
+			font-size: 20px;
+		}
 	}
 }

--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -30,7 +30,7 @@
         <% end %>
 
         <a href="<%= news_path(n) %>">
-          <%= image_tag left_image, alt: 'test', class: 'item-image' %>
+          <%= image_tag left_image, alt: 'test', class: 'item-image news_page_image hidden-xs' %>
         </a>
 
         <div class="item-desc">


### PR DESCRIPTION
Addresses #1628

I shrunk the titles, and added the first part of the body of the news item to the box.  There's apparently no convenient way to do multi-line truncations in CSS, so I just have a gradient fade the overflow away.
