### PR TITLE
Dataset URLs for projects ending in a trailing forward slash work properly again

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -178,7 +178,7 @@
                <% else %>
                	<td style="max-width:60px"><div class="truncate"><%= link_to s.owner.name, user_path(s.owner) %></div></td>
                <% end %>
-                  <td style="max-width:200px"><div class="truncate dset" title="Created <%=s.created_at.strftime("%B %d, %Y")%>"><%= link_to s.title, "#{params[:id]}/data_sets/#{s.id}" %></div></td>
+                 <td style="max-width:200px"><div class="truncate dset" title="Created <%=s.created_at.strftime("%B %d, %Y")%>"><%= link_to s.title, "/projects/#{params[:id]}/data_sets/#{s.id}" %></div></td>
                  <td>
                  <div class="controls" style="">                  
                       <% if can_edit? s %>


### PR DESCRIPTION
Addresses #1680 

See #1684 for an explanation of how, what and why.
