### PR TITLE
Nudge the dataset selection dropdown to the left so it doesn't hide the things

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -98,7 +98,7 @@
                   <i class="fa fa-check-square-o"></i>
                   <span class="caret"></span>
                 </a>
-                <ul class="dropdown-menu" role="menu">
+                <ul class="dropdown-menu" role="menu" style="left:-200%;">
                     <li role="presentation">
                       <a role="menuitem" href="javascript:void(0);" id="check_all"><i class="fa fa-check-square-o"></i> All</a>
                     </li>


### PR DESCRIPTION
Addresses #1709 - I really wouldn't call it _broken_, just mildly annoying.  You can still see everything, it just looks extremely stupid.

I moved the dropdown to the left so it's not outside of the div that hides overflow.  This pull request is maybe 10x more involved than the fix itself.
