### PR TITLE
Editing a vis description no longer jumps to the top of the page

### DIFF
--- a/app/views/shared/_content.html.erb
+++ b/app/views/shared/_content.html.erb
@@ -28,7 +28,7 @@
     <div>
       <% if can_edit?(obj) && (content.nil? || content.empty?) %>
         <p style="text-align: center">
-          <%= link_to(image_tag("green_plus_icon.png"), "javascript:;", id: 'add-content-image') %>
+          <%= link_to(image_tag('green_plus_icon.png'), '#', id: 'add-content-image') %>
         </p>
       <% else %>
         <%= raw content %>

--- a/lib/assets/javascripts/content_edit_pane.js.coffee
+++ b/lib/assets/javascripts/content_edit_pane.js.coffee
@@ -103,7 +103,8 @@ $ ->
                 
       return editor
   
-  ($ '#content_edit').click () ->
+  ($ '#content_edit').click (e) ->
+    e.preventDefault()
     ck = ($ document).find('.content:visible')[0]
     ($ @).hide()
     turn_on_ck(ck)


### PR DESCRIPTION
Addresses #1704

Technically, links that don't go anywhere (and shouldn't move the page either) should have an href of 'javascript:;', but the rest of the site calls e.preventDefault(); in a JS click event so I just went with that.  This is a super nitpicky thing and not worth combing over the entire site just to fix.
