### PR TITLE
Add images to the list of automatically included files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: https://github.com/asalani93/better-colorpicker
-  revision: 1946b9645e8b8593010b779b54c00a2b282282d2
+  revision: 80a17d5554ec64954beb87a6459a59c418f8096e
   specs:
     better_colorpicker (0.0.1)
       rails (~> 4.1.4)
@@ -211,7 +211,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (1.2.1)
+    tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.5.3)
       execjs (>= 0.3.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,9 @@ module Rsense
     # Enable the asset pipeline
     config.assets.enabled = true
 
+    # This is so that gems with images accompanying them in the vendor or lib folders still get compiled
+    config.assets.precompile += %w(*.png *.jpg *.jpeg *.gif)
+
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
   end


### PR DESCRIPTION
Rails ignores non-CSS or JS assets in /lib and /vendor - added a line that remedies that.  This should properly load images for gems (namely my colorpicker).
