### PR TITLE
Turn off autofill for the new email address field

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -61,7 +61,7 @@
             <div class="form-group">
               <p>
                 <%= ff.label :email, "New Email:" %>
-                <%= ff.text_field(:email, class: "form-control")%>
+                <%= ff.text_field(:email, class: "form-control", value: "")%>
               </p>
             </div>  
             <div class="form-group">


### PR DESCRIPTION
Addresses #1727

Previously, when prompted to enter a new email, the field for your new email was already populated with your old email.  Now it doesn't - autofill won't populate fields with default values.
