### PR TITLE
Select all option for Scatter Plot, Bar Chart, and Timeline, v2!

### DIFF
--- a/lib/assets/javascripts/highvis/baseVis.coffee.erb
+++ b/lib/assets/javascripts/highvis/baseVis.coffee.erb
@@ -181,7 +181,6 @@ $ ->
 
         ($ '#select-all-y').on('click', () ->
           if data.normalFields.length != globals.fieldSelection.length
-            console.log 'should be checking...'
             ($ '#yAxisControl').find('.y_axis_input').each (i,j) ->
               ($ j).prop('checked', true)
             globals.fieldSelection = data.normalFields.slice(0)


### PR DESCRIPTION
Adds a Select all option for the Y Axis in Scatter Plot, Bar Chart, and Timeline.  Per @JayPoulz's request, I built the functionality directly into the BaseVis class.

Addresses issue #1477
