### PR TITLE
Page no longer jumps to top when adding a description to a visualization

### DIFF
--- a/app/views/shared/_content.html.erb
+++ b/app/views/shared/_content.html.erb
@@ -28,7 +28,7 @@
     <div>
       <% if can_edit?(obj) && (content.nil? || content.empty?) %>
         <p style="text-align: center">
-          <%= link_to(image_tag('green_plus_icon.png'), '#', id: 'add-content-image') %>
+          <%= link_to(image_tag('green_plus_icon.png'), 'javascript:;', id: 'add-content-image') %>
         </p>
       <% else %>
         <%= raw content %>


### PR DESCRIPTION
Addresses #1704

So I fixed the wrong thing last time.  Apparently, I can't read.  Now, clicking on the giant green plus sign no longer relocates you to the top of the page.

EDIT: Apparently, my old fix did work, it just got deleted along with the entirety of CK Editor.
