### PR TITLE
Minor documentation correction

### DIFF
--- a/app/views/home/api_v1.html.erb
+++ b/app/views/home/api_v1.html.erb
@@ -174,8 +174,8 @@
       {
         "project_id" =>  integer,
         "field_type" =>  integer,
-        "field_name" => string,
-        "units" => string,
+        "name" => string,
+        "unit" => string,
         "restrictions" => string
       }
   }


### PR DESCRIPTION
Addresses #1755 .

So, the documentation regarding how to add fields to a project was apparently never right.  'field_name' should have been 'name' and 'units' should have been 'unit'.  I'm going to assume this isn't a breaking change to the API, considering that the API itself didn't change (and has never changed - it's been this way since 1/20/14 according to git).  The documentation now merely represents the universe we currently inhabit, and not the bizarro one where 'units' and 'field_name' are valid parameters used in creating a field.
