### PR TITLE
Group By Field Selection for Bar Charts reevaluated

### DIFF
--- a/lib/assets/javascripts/highvis/bar.coffee
+++ b/lib/assets/javascripts/highvis/bar.coffee
@@ -72,7 +72,6 @@ $ ->
           yAxis:
             type: if globals.logY is 1 then 'logarithmic' else 'linear'
         if defaultGroupBy
-          console.log 'running'
           data.setGroupIndex(data.textFields[2])
           globals.groupSelection = for vals, keys in data.groups
             Number keys


### PR DESCRIPTION
Towards (addresses?) issue #1762 

If a project has a text field, bar chart will automatically group based upon the text field by default, creating the behavior @jaypoulz specified.  However, this choice is then preserved upon navigation to other visualizations, which I am not necessarily sure is desired.  This behavior does not occur for saved visualizations.
