### PR TITLE
Adding case insensitivity check to field name validator

### DIFF
--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -1,7 +1,7 @@
 include ApplicationHelper
 class Field < ActiveRecord::Base
   validates_presence_of :project_id, :field_type, :name
-  validates_uniqueness_of :name, scope: :project_id, :case_sensitive => false
+  validates_uniqueness_of :name, scope: :project_id, case_sensitive: false
   belongs_to :project
   serialize :restrictions, JSON
   alias_attribute :owner, :project


### PR DESCRIPTION
New validator line:

``` ruby
validates_uniqueness_of :name, scope: :project_id, case_sensitive: false
```

This is in reference to #1699
