### PR TITLE
Timestamp regex in file upload fixed

### DIFF
--- a/lib/file_uploader.rb
+++ b/lib/file_uploader.rb
@@ -166,7 +166,7 @@ class FileUploader
     types['latitude'] = []
     types['longitude'] = []
 
-    regex = %r{(?<year>\d{4})(-|\/)(?<month>\d{1,2})(-|\/)(?<day>\d{1,2})}
+    regex = %r{((?<year>\d{4})(-|\/)(?<month>\d{1,2})(-|\/)(?<day>\d{1,2})|([uU]\s\d+))}
 
     data_set.each do |column|
       if (column[1]).map { |dp| (regex =~ dp) }.reduce(:&)


### PR DESCRIPTION
Fixed the file upload regex to correctly identify timestamps (in the correct format: yyyy-/mm-/dd-/) as timestamps.
#1746
