### PR TITLE
Fix histogram bin sizing controls

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -286,9 +286,7 @@ $ ->
           globals.toolsOpen = (globals.toolsOpen + 1) % 2
 
         ($ "#binSizeInput").keydown (e) =>
-          console.log 
           if e.keyCode == 13
-            console.log 'b'
 
             newBinSize = Number ($ '#binSizeInput').val()
 
@@ -300,8 +298,6 @@ $ ->
               ($ "#binSizeInput").errorFlash()
               return
 
-            console.log "MAX_NUM_BINS: #{@MAX_NUM_BINS}"
-            console.log "Bin Count:    #{((@globalmax - @globalmin)/newBinSize)}"
             if ((@globalmax - @globalmin) / newBinSize) < @MAX_NUM_BINS
               @binSize = newBinSize
               @update()


### PR DESCRIPTION
Addresses #1769 

The keydown event handler for the bin size text box used weird, non-standard ways of getting event info.  This is no longer the case, and that works properly

I also turned the bin size slider around so that when you move it to the right, the bin size goes up.  I was trying to change it so you would change the number of bins, but after thinking about it, that doesn't seem as useful as changing bin size.
