### PR TITLE
Analysis types for Pie Chart!

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -107,14 +107,7 @@ $ ->
           @chart.series[@chart.series.length - 1].remove false
 
         ### --- ###
-        tempGroupIDValuePairs = for groupName, groupIndex in data.groups when groupIndex in globals.groupSelection
-          switch @analysisType
-            when @ANALYSISTYPE_TOTAL    then [groupIndex, (data.getTotal     @sortField, groupIndex)]
-            when @ANALYSISTYPE_MAX      then [groupIndex, (data.getMax       @sortField, groupIndex)]
-            when @ANALYSISTYPE_MIN      then [groupIndex, (data.getMin       @sortField, groupIndex)]
-            when @ANALYSISTYPE_MEAN     then [groupIndex, (data.getMean      @sortField, groupIndex)]
-            when @ANALYSISTYPE_MEDIAN   then [groupIndex, (data.getMedian    @sortField, groupIndex)]
-            when @ANALYSISTYPE_COUNT    then [groupIndex, (data.getCount     @sortField, groupIndex)]
+        tempGroupIDValuePairs = @getGroupedData(@displayField, @sortField)
 
         if @sortField != @SORT_DEFAULT
           fieldSortedGroupIDValuePairs = tempGroupIDValuePairs.sort (a,b) ->
@@ -181,81 +174,7 @@ $ ->
             type: 'area'
             xAxis: 1
 
-      drawToolControls: ->
-
-        controls =  '<div id="toolControl" class="vis_controls">'
-
-        controls += "<h3 class='clean_shrink'><a href='#'>Tools:</a></h3>"
-        controls += "<div class='outer_control_div'>"
-
-        controls += "<div class='inner_control_div'>"
-        controls += 'Sort by: <select id="sortField" class="sortField form-control">'
-
-        tempFields = for fieldID in data.normalFields
-          [fieldID, data.fields[fieldID].fieldName]
-
-        tempFields = [].concat [[@SORT_DEFAULT, 'Group Name']], tempFields
-
-        for [fieldID, fieldName] in tempFields
-          selected = if @sortField is fieldID then 'selected' else ''
-          controls += "<option value='#{fieldID}' #{selected}>#{fieldName}</option>"
-
-        controls += '</select></div><br>'
-
-        controls += "<h4 class='clean_shrink'>Analysis Type</h4><div id='analysis_types'>"
-
-        for typestring, type in @analysisTypeNames
-
-          controls += "<div class='inner_control_div'>"
-
-          controls += "<div class='radio'><label><input type='radio' class='analysisType' "
-          controls += "name='analysisTypeSelector' value='"
-          controls += "#{type}' #{if type is @analysisType then 'checked' else ''}> "
-
-          switch typestring
-            when 'Max' then controls += 'Maximum </label> </div>'
-            when 'Min' then controls += 'Minimum </label> </div>'
-            when 'Mean' then controls += 'Mean (Average)</label></div>'
-            else controls += "#{typestring} </label></div>"
-
-          controls += '</div>'
-
-        controls += "</div><h4 class='clean_shrink'>Other</h4>"
-
-        if data.logSafe is 1
-          controls += '<div class="inner_control_div">'
-          controls += "<div class='checkbox'><label><input class='logY_box' type='checkbox' "
-          controls += "name='tooltip_selector' #{if globals.logY is 1 then 'checked' else ''}/> "
-          controls += "Logarithmic Y Axis</label></div>"
-          controls += "</div>"
-
-        controls += '</div></div>'
-
-        ### --- ###
-        # Write HTML
-        ($ '#controldiv').append controls
-
-        ($ '.analysisType').change (e) =>
-          @analysisType = Number e.target.value
-          @delayedUpdate()
-
-        ($ '#sortField').change (e) =>
-          @sortField = Number e.target.value
-          @delayedUpdate()
-
-        ($ '.logY_box').click (e) =>
-          globals.logY = (globals.logY + 1) % 2
-          @start()
-
-        # Set up accordion
-        globals.toolsOpen ?= 0
-
-        ($ '#toolControl').accordion
-          collapsible:true
-          active:globals.toolsOpen
-
-        ($ '#toolControl > h3').click ->
-          globals.toolsOpen = (globals.toolsOpen + 1) % 2
+      
 
       drawYAxisControls: ->
         super()
@@ -264,7 +183,7 @@ $ ->
         super()
         @drawGroupControls()
         @drawYAxisControls()
-        @drawToolControls()
+        @drawToolControls(true, true)
         @drawSaveControls()
 
 

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -87,7 +87,32 @@ $ ->
 
           See logged stack trace in console.
           """
-
+      ###
+      Calculate grouped data with a specific analysis yype for Bar Chart and Pie Chart.
+      ###
+      getGroupedData: (display, sort = null) ->
+        
+        # Pie Chart data format
+        if sort is null
+          for groupName, groupIndex in data.groups when groupIndex in globals.groupSelection
+            switch @analysisType
+              when @ANALYSISTYPE_TOTAL    then [groupName, (data.getTotal     display, groupIndex)]
+              when @ANALYSISTYPE_MAX      then [groupName, (data.getMax       display, groupIndex)]
+              when @ANALYSISTYPE_MIN      then [groupName, (data.getMin       display, groupIndex)]
+              when @ANALYSISTYPE_MEAN     then [groupName, (data.getMean      display, groupIndex)]
+              when @ANALYSISTYPE_MEDIAN   then [groupName, (data.getMedian    display, groupIndex)]
+              when @ANALYSISTYPE_COUNT    then [groupName, (data.getCount     display, groupIndex)]
+        
+        # Bar Chart data format
+        else
+          for groupName, groupIndex in data.groups when groupIndex in globals.groupSelection
+            switch @analysisType
+              when @ANALYSISTYPE_TOTAL    then [groupIndex, (data.getTotal     sort, groupIndex)]
+              when @ANALYSISTYPE_MAX      then [groupIndex, (data.getMax       sort, groupIndex)]
+              when @ANALYSISTYPE_MIN      then [groupIndex, (data.getMin       sort, groupIndex)]
+              when @ANALYSISTYPE_MEAN     then [groupIndex, (data.getMean      sort, groupIndex)]
+              when @ANALYSISTYPE_MEDIAN   then [groupIndex, (data.getMedian    sort, groupIndex)]
+              when @ANALYSISTYPE_COUNT    then [groupIndex, (data.getCount     sort, groupIndex)]
       ###
       Draws controls
       Derived classes should write control HTML and bind handlers using the method such as drawGroupControls.
@@ -418,7 +443,82 @@ $ ->
 
         ($ '#saveControl > h3').click ->
           globals.saveOpen = (globals.saveOpen + 1) % 2
+      ###
+      Draws the Tool Controls for Bar Chart and Pie Chart:
+      ###
+      drawToolControls: (sortBy = false, logYAxis = false) ->
 
+        controls =  '<div id="toolControl" class="vis_controls">'
+
+        controls += "<h3 class='clean_shrink'><a href='#'>Tools:</a></h3>"
+        controls += "<div class='outer_control_div'>"
+        if sortBy
+          controls += "<div class='inner_control_div'>"
+          controls += 'Sort by: <select id="sortField" class="sortField form-control">'
+
+          tempFields = for fieldID in data.normalFields
+            [fieldID, data.fields[fieldID].fieldName]
+
+          tempFields = [].concat [[@SORT_DEFAULT, 'Group Name']], tempFields
+
+          for [fieldID, fieldName] in tempFields
+            selected = if @sortField is fieldID then 'selected' else ''
+            controls += "<option value='#{fieldID}' #{selected}>#{fieldName}</option>"
+
+          controls += '</select></div><br>'
+
+        controls += "<h4 class='clean_shrink'>Analysis Type</h4><div id='analysis_types'>"
+        for typestring, type in @analysisTypeNames
+
+          controls += "<div class='inner_control_div'>"
+
+          controls += "<div class='radio'><label><input type='radio' class='analysisType' "
+          controls += "name='analysisTypeSelector' value='"
+          controls += "#{type}' #{if type is @analysisType then 'checked' else ''}> "
+
+          switch typestring
+            when 'Max' then controls += 'Maximum </label> </div>'
+            when 'Min' then controls += 'Minimum </label> </div>'
+            when 'Mean' then controls += 'Mean (Average)</label></div>'
+            else controls += "#{typestring} </label></div>"
+
+          controls += '</div>'
+
+        if data.logSafe is 1 and logYAxis
+          controls += "</div><h4 class='clean_shrink'>Other</h4>"
+          controls += '<div class="inner_control_div">'
+          controls += "<div class='checkbox'><label><input class='logY_box' type='checkbox' "
+          controls += "name='tooltip_selector' #{if globals.logY is 1 then 'checked' else ''}/> "
+          controls += "Logarithmic Y Axis</label></div>"
+          controls += "</div>"
+
+        controls += '</div></div>'
+
+        ### --- ###
+        # Write HTML
+        ($ '#controldiv').append controls
+
+        ($ '.analysisType').change (e) =>
+          @analysisType = Number e.target.value
+          @delayedUpdate()
+
+        ($ '#sortField').change (e) =>
+          @sortField = Number e.target.value
+          @delayedUpdate()
+
+        ($ '.logY_box').click (e) =>
+          globals.logY = (globals.logY + 1) % 2
+          @start()
+
+        # Set up accordion
+        globals.toolsOpen ?= 0
+
+        ($ '#toolControl').accordion
+          collapsible:true
+          active:globals.toolsOpen
+
+        ($ '#toolControl > h3').click ->
+          globals.toolsOpen = (globals.toolsOpen + 1) % 2
       ###
       Hides the control div and remembers its previous size.
       ###

--- a/app/assets/javascripts/visualizations/highvis/pie.coffee
+++ b/app/assets/javascripts/visualizations/highvis/pie.coffee
@@ -40,16 +40,28 @@ $ ->
             data.textFields[2]
           else
             'Percent'
+      ANALYSISTYPE_TOTAL:     0
+      ANALYSISTYPE_MAX:       1
+      ANALYSISTYPE_MIN:       2
+      ANALYSISTYPE_MEAN:      3
+      ANALYSISTYPE_MEDIAN:    4
+      ANALYSISTYPE_COUNT:     5
 
+
+      analysisTypeNames: ["Total","Max","Min","Mean","Median","Row Count"]
+
+      analysisType:         0
+      restoreAnalysisType:  false
+      savedAnalysisType:    0
+      
       start: () ->
         super()
 
       update: () ->
         @selectName = data.fields[data.groupingFieldIndex].fieldName
-        @getGroupedData()
+        @displayData = @getGroupedData(@displayField)
         while @chart.series.length > 0
           @chart.series[@chart.series.length - 1].remove false
-
         @displayColors = []
         for number in globals.groupSelection
           @displayColors.push(globals.colors[number])
@@ -59,31 +71,12 @@ $ ->
           colors: @displayColors
         @chart.setTitle { text: "#{@selectName} by #{data.fields[@displayField].fieldName}" }
         @chart.addSeries options, false
-
         @chart.redraw()
-
-      getGroupedData: ->
-        @displayData = data.dataPoints.reduce (prev, next) =>
-          if typeof prev[next[data.groupingFieldIndex]] != "undefined"
-            prev[next[data.groupingFieldIndex]] = prev[next[data.groupingFieldIndex]] + next[@displayField]
-          else
-            prev[next[data.groupingFieldIndex]] = next[@displayField]
-          prev
-        , {}
-        @displayData = Object.keys(@displayData).reduce (prev, key) =>
-          if data.groups.indexOf(key.toLowerCase()) in globals.groupSelection
-            if (grouping[0] for grouping in prev).indexOf(key.toLowerCase()) isnt -1
-              prev.indexOf(grouping)[1] = @displayData[key] + prev.indexOf(grouping)[1]
-            else prev.push [key.toLowerCase() or "No #{@selectName}", @displayData[key]]
-          prev
-        , []
 
       buildOptions: ->
         super()
-
         self = this
         @chartOptions
-
         $.extend true, @chartOptions,
           chart:
             type: "pie"
@@ -101,6 +94,7 @@ $ ->
         super()
         @drawGroupControls false, false, false
         @drawYAxisControls true, false # Naming here is less than ideal
+        @drawToolControls()
         @drawSaveControls()
 
     if "Pie" in data.relVis


### PR DESCRIPTION
Addresses issue #1799 per @fgmart 's request.

**Change summary:**
1.  The code that drew the "Tools" control div in Bar Charts (including Sort Field, Analysis Type, and Logarithmic Y Axis) has been moved to the BaseVis class as the drawToolControls method.
2.  Pie Charts and Bar Charts now call this function to draw their "Tools" control div with two flags, which determine whether or not the Sort By controls and Logarithmic Y Axis Controls are drawn, respectively, since these controls only pertain to Bar Charts.
3.  Added a getGroupedData function to BaseVis that returns the data to be displayed in the Highcharts series for Bar Charts and Pie Charts.  The exact data that is returned is dictated by the chart's analysis type, and the data is returned in two different formats for bar charts and pie charts for compatibility with existing code.
4. Removed existing code to compute the data to be displayed for Pie Charts, as it was not conducive to implementing analysis types.
