### PR TITLE
Minor Bugfixes for release tomorrow.

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/pie.coffee
+++ b/app/assets/javascripts/visualizations/highvis/pie.coffee
@@ -54,7 +54,7 @@ $ ->
 
         @displayColors = []
         for number in data.groupSelection
-          @displayColors.push(globals.configs.colors[number])
+          @displayColors.push(globals.configs.colors[number % globals.configs.colors.length])
         options =
           showInLegend: false
           data: @displayData

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -224,12 +224,6 @@ body {
     text-align: right; 
     margin-top: 1em;
   }
-  #add-content-image{
-    img{
-      height:390px;
-      width:100%;
-    }
-  }
   overflow:hidden !important;
   iframe{
     width: 100%; 
@@ -244,5 +238,12 @@ body {
     width: 100%;
     height: auto;
   }
+  #add-content-image{
+    img{
+      height: 250px !important;
+      width: 250px !important;
+    }
+  }
 }
+
 

--- a/app/views/shared/_content.html.erb
+++ b/app/views/shared/_content.html.erb
@@ -27,8 +27,8 @@
 
     <div>
     <% if can_edit?(obj) && (content.nil? || content.empty?) %>
-      <p id="text-align: center">
-        <%= link_to(image_tag('green_plus_icon.png'), 'javascript:;', id: 'add-content-image') %>
+      <p style="text-align: center">
+        <%= link_to(image_tag('green_plus_icon.png'), 'javascript:;', size: "250x250", id: 'add-content-image') %>
       </p>
     <% else %>
       <%= raw content %>


### PR DESCRIPTION
Addresses issue #1816 

Change Summary:
1.  Pie Charts properly reuse colors.
2.  My last Summernote patch unnecessarily resized the green plus icon in Summernote.  The icon now displays properly again (centered, 250 x 250 pixels).
