### PR TITLE
Summernote Hypertext can now be modified through link controls

### DIFF
--- a/app/assets/javascripts/rich_text.js.coffee
+++ b/app/assets/javascripts/rich_text.js.coffee
@@ -3,15 +3,16 @@ showEditor = () ->
   ($ '#content-viewer').hide()
   ($ '#content-editor').show()
   ($ '#content-edit-btn').hide()
-  ($ '#content-area').summernote(
+  ($ '#content-area').summernote
     height: 400,
-    toolbar: [
-      ['style', ['style', 'bold', 'italic']],
-      ['para', ['ul', 'ol', 'paragraph']],
-      ['misc', ['codeview']],
-      ['insert', ['picture', 'link', 'video']],
-    ]
-  )
+    toolbar:
+      [
+        ['style', ['style', 'bold', 'italic']],
+        ['para', ['ul', 'ol', 'paragraph']],
+        ['misc', ['codeview']],
+        ['insert', ['picture', 'link', 'video']]
+      ]
+
   ($ '.btn.btn-default.btn-sm.btn-small').on 'click', (e) ->
     if e.currentTarget.firstChild.className.search 'icon-link' isnt -1
       if ($ '.note-link-url').val() is '' and ($ '.note-link-text').val() is ''

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -179,7 +179,7 @@ class MediaObject < ActiveRecord::Base
         link.content = external_link
       end
     end
-    text = Nokogiri::HTML.fragment AutoHtml.auto_html(text){
+    text = Nokogiri::HTML.fragment AutoHtml.auto_html(text) {
       youtube(autoplay: false, allowfullscreen: true)
     }
     text.to_s


### PR DESCRIPTION
Minor patch to address issue #1748 .  Also added a small modification to my previous patch for #1765 per @jaypoulz's request. 

**Change Summary:**

-Hypertext can be modified through the "Link" button on the tool bar (addressed simply by removing the disabled class from the button that submitted the form if the user attempted to save a hyperlink whose URL wasn't modified.  
-If the user attempts to add a YouTube video via the "Link" button on the toolbar, an embedded iframe will be placed in the content field, replacing the link they provided, regardless of the text.  This prevents the awkward situation of having to strip the href properties from the anchor tags, creating dead links that look as though they go somewhere.
