### PR TITLE
Hiding featured media label on visualizations

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,9 +61,7 @@
           </ul>
           <ul class="nav navbar-nav navbar-right">
             <% if @cur_user.try(:id) %>
-              <li class="navbtn" title="Click to view <%= @cur_user.name %>'s profile page">
               <li class="navbtn" title="Click to view <%= @cur_user.name %>'s profile page"><%= link_to @cur_user.name, user_path(@cur_user)%></li>
-              </li>
               <li class="divider"></li>
               <li class="navbtn"><%= link_to "Logout", login_path, method: :delete%></li>
             <% else %>


### PR DESCRIPTION
I hid the featured media label on visualizations since imaginemagick is not working for me, and I was unable to finish allowing visualizations to have featured images. This is a temporary fix until I get that gem working again.

Towards #1775.
