### PR TITLE
Preventing long names from overflowing on nav bar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,7 +61,13 @@
           </ul>
           <ul class="nav navbar-nav navbar-right">
             <% if @cur_user.try(:id) %>
-              <li class="navbtn" title="Click to view <%= @cur_user.name %>'s profile page"><%= link_to @cur_user.name, user_path(@cur_user)%></li>
+              <li class="navbtn" title="Click to view <%= @cur_user.name %>'s profile page">
+              <% if @cur_user.name.length < 50 %>
+                <%= link_to @cur_user.name, user_path(@cur_user) %>
+              <% else %>
+                <%= link_to "My Account", user_path(@cur_user) %>
+              <% end %>
+              </li>
               <li class="divider"></li>
               <li class="navbtn"><%= link_to "Logout", login_path, method: :delete%></li>
             <% else %>


### PR DESCRIPTION
Addresses #1815. Displays "My Account" when user name is too long and overflows on the nav bar.
