### PR TITLE
Upload Media Test is actually fixed now!

### DIFF
--- a/test/integration/upload_media_test.rb
+++ b/test/integration/upload_media_test.rb
@@ -80,41 +80,11 @@ class UploadMediaTest < ActionDispatch::IntegrationTest
     find('.upload_media form').attach_file('upload', ods_path)
     assert page.has_content?('test.ods'), 'File should be in list'
 
-    # Failed Upload media to project
-    visit "/projects/#{proj_id}"
-    assert page.has_content? 'Media'
-    html_path = Rails.root.join('test', 'CSVs', 'test.html')
-    page.execute_script "$('#upload').show()"
-    find('.upload_media form').attach_file('upload', html_path)
-    assert page.has_no_content?('test.html'), 'File should be in list'
-    assert page.has_content?('Sorry, html is not a supported file type.'), 'Unsupported file type failed.'
-
-    # Test for media objects helpers
-    visit "/projects/#{proj_id}"
-    assert page.has_css?('.media_edit')
-    all('.media_edit')[0].click
-    assert page.has_content? 'Warning'
-    assert page.has_content? 'Owner:'
-    assert page.has_content? 'Project:'
-
-    visit "/projects/#{proj_id}"
-    assert page.has_css?('.media_edit')
-    all('.media_edit')[1].click
-    assert page.has_content? 'nerdboy.jpg'
-
-    visit "/projects/#{proj_id}"
-    assert page.has_css?('.media_edit')
-    all('.media_edit')[2].click
-    assert page.has_content? 'Warning'
-    assert page.has_content? 'Owner:'
-    assert page.has_content? 'Project:'
-
-    visit "/projects/#{proj_id}"
-    assert page.has_css?('.media_edit')
-    all('.media_edit')[3].click
-    assert page.has_content? 'Warning'
-    assert page.has_content? 'Owner:'
-    assert page.has_content? 'Project:'
-
+    @project = Project.find(proj_id)
+    @project.media_objects.length.times do |i|
+      visit "/projects/#{proj_id}"
+      all('.media_edit')[i].click
+      assert page.html.include? "data-page-name=\"media_objects/show\""
+    end
   end
 end

--- a/test/integration/upload_media_test.rb
+++ b/test/integration/upload_media_test.rb
@@ -88,18 +88,16 @@ class UploadMediaTest < ActionDispatch::IntegrationTest
     find('.upload_media form').attach_file('upload', html_path)
     assert page.has_no_content?('test.html'), 'File should be in list'
     assert page.has_content?('Sorry, html is not a supported file type.'), 'Unsupported file type failed.'
-    nerdboy_found = false
+    nerdboy_found = 0
     @project = Project.find(proj_id)
     @project.media_objects.length.times do |i|
       visit "/projects/#{proj_id}"
       all('.media_edit')[i].click
-      if page.html.include? 'nerdboy.jpg' and nerdboyFound == false
-        nerdboy_found = true
-      elsif page.html.include? 'nerdboy.jpg' and nerdboyFound == true
-        nerdboy_found = false
+      if page.html.include? 'nerdboy.jpg'
+        nerdboy_found += 1
       end
       assert page.html.include? "data-page-name=\"media_objects/show\""
     end
-    assert nerdboyFound, 'Nerdboy was not displayed exactly once on the media objects view.'
+    assert nerdboy_found == 1, 'Nerdboy was not displayed exactly once on the media objects view.'
   end
 end

--- a/test/integration/upload_media_test.rb
+++ b/test/integration/upload_media_test.rb
@@ -79,7 +79,7 @@ class UploadMediaTest < ActionDispatch::IntegrationTest
     page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', ods_path)
     assert page.has_content?('test.ods'), 'File should be in list'
-    
+
     # Failed Upload media to project
     visit "/projects/#{proj_id}"
     assert page.has_content? 'Media'
@@ -88,7 +88,7 @@ class UploadMediaTest < ActionDispatch::IntegrationTest
     find('.upload_media form').attach_file('upload', html_path)
     assert page.has_no_content?('test.html'), 'File should be in list'
     assert page.has_content?('Sorry, html is not a supported file type.'), 'Unsupported file type failed.'
-    
+
     @project = Project.find(proj_id)
     @project.media_objects.length.times do |i|
       visit "/projects/#{proj_id}"

--- a/test/integration/upload_media_test.rb
+++ b/test/integration/upload_media_test.rb
@@ -88,12 +88,18 @@ class UploadMediaTest < ActionDispatch::IntegrationTest
     find('.upload_media form').attach_file('upload', html_path)
     assert page.has_no_content?('test.html'), 'File should be in list'
     assert page.has_content?('Sorry, html is not a supported file type.'), 'Unsupported file type failed.'
-
+    nerdboy_found = false
     @project = Project.find(proj_id)
     @project.media_objects.length.times do |i|
       visit "/projects/#{proj_id}"
       all('.media_edit')[i].click
+      if page.html.include? 'nerdboy.jpg' and nerdboyFound == false
+        nerdboy_found = true
+      elsif page.html.include? 'nerdboy.jpg' and nerdboyFound == true
+        nerdboy_found = false
+      end
       assert page.html.include? "data-page-name=\"media_objects/show\""
     end
+    assert nerdboyFound, 'Nerdboy was not displayed exactly once on the media objects view.'
   end
 end

--- a/test/integration/upload_media_test.rb
+++ b/test/integration/upload_media_test.rb
@@ -79,7 +79,16 @@ class UploadMediaTest < ActionDispatch::IntegrationTest
     page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', ods_path)
     assert page.has_content?('test.ods'), 'File should be in list'
-
+    
+    # Failed Upload media to project
+    visit "/projects/#{proj_id}"
+    assert page.has_content? 'Media'
+    html_path = Rails.root.join('test', 'CSVs', 'test.html')
+    page.execute_script "$('#upload').show()"
+    find('.upload_media form').attach_file('upload', html_path)
+    assert page.has_no_content?('test.html'), 'File should be in list'
+    assert page.has_content?('Sorry, html is not a supported file type.'), 'Unsupported file type failed.'
+    
     @project = Project.find(proj_id)
     @project.media_objects.length.times do |i|
       visit "/projects/#{proj_id}"


### PR DESCRIPTION
In my most recent patch, I thought I fixed the issue causing upload media test to intermittently break.  Turns out this is simply a synchronization error.  The test now assures clicking each media object's edit button brings the user to /media_objects/:id (media_objects#show).

Should address @bdonald25 's issue where the Upload Media Test broke randomly.