### PR TITLE
Fixed project cloning having a description that links back to old project's media

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -69,7 +69,7 @@ class ProjectsController < ApplicationController
 
     # checks for fields
     @has_fields = false
-    if  @project.fields.count > 0
+    if @project.fields.count > 0
       @has_fields = true
     end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -208,8 +208,6 @@ class Project < ActiveRecord::Base
       new_project.title = params[:project_name]
     end
 
-    new_project.save
-
     # Clone fields
     field_map = {}
     fields.each do |f|
@@ -228,14 +226,21 @@ class Project < ActiveRecord::Base
       nmo.user_id = user_id
       nmo.save!
 
+      new_project.media_objects << nmo
+
+      # Replace old the old mo's path with the new mo's path whenever it
+      # occurs in the project's description
       unless content.nil?
-        content.gsub! mo.src, nmo.src
+        new_project.content.gsub! mo.src, nmo.src
       end
 
       if new_project.featured_media_id == mo.id
         new_project.featured_media_id = nmo.id
       end
     end
+
+    # Save the project now that all meta data is cloned
+    new_project.save
 
     # Clone datasets
     if params[:clone_datasets]
@@ -270,6 +275,7 @@ class Project < ActiveRecord::Base
         nds.save!
       end
     end
+
     new_project
   end
 

--- a/app/views/projects/clone.html.erb
+++ b/app/views/projects/clone.html.erb
@@ -4,7 +4,7 @@
     <div class="alert alert-error">
       <button type="button" class="close" data-dismiss="alert">&times;</button>
       <h3><%= pluralize(@clone.errors.count, "error") %> were encountered:</h3>
-      
+
       <ul>
         <% @clone.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
@@ -16,34 +16,43 @@
   <div class="col-xs-12 col-sm-8 col-sm-offset-2">
     <%= form_for @clone, url: {action: 'create'} do |ff| %>
       <div class="panel panel-default">
-      
+
         <div class="panel-heading">
           <h1>Cloning: <%= @project.title %></h1>
         </div>
-        
+
         <div class="panel-body">
           <div class="form-group">
             <%= label_tag(:name, "Title:") %>
-            <%= text_field_tag :project_name, @project.title + " (clone)", class: "form-control", autofocus: true %>
+            <%= text_field_tag :project_name, @project.title + " (clone)",
+                class: "form-control", autofocus: true %>
           </div>
-          
+
           <% if @project.data_sets.any? %>
-			<div class="form-group">
-			   <%= label_tag(:clone_datasets, "Clone Data Sets:") %>
-			   <%= check_box_tag :clone_datasets, class: "form-control", autofocus: true %>
-			</div>
-		  <% end %>
-          
+            <div class="form-group">
+              <%= label_tag(:clone_datasets, "Clone Data Sets:") %>
+              <%= check_box_tag :clone_datasets, class: "form-control",
+                  autofocus: true %>
+            </div>
+          <% end %>
+
           <div style="text-align:center;">
-	    <span style="color:#BBB;">Media objects will automatically be cloned (e.g. photos, text, and files)</span>
-	  </div>
-          
+            <span style="color:#BBB;">
+              Media objects will automatically be cloned
+              (e.g. photos, text, and files)
+            </span>
+          </div>
+
           <%= hidden_field_tag(:project_id, @project.id) %>
         </div>
-        
+
         <div class="panel-footer text-center">
-          <a href='<%= url_for @project %>'> <button type="button" class="btn btn-danger"> Cancel </button></a>
-          <button type="submit" name="commit" class="btn btn-success"> Clone Project </button>
+          <a href='<%= url_for @project %>'>
+            <button type="button" class="btn btn-danger"> Cancel </button>
+          </a>
+          <button type="submit" name="commit" class="btn btn-success">
+            Clone Project
+          </button>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Addresses #1668 

There were a few issues:
- New, cloned media objects weren't being pushed back into the new project's own media objects array
- The project was being saved before media was even cloned
- Whoever wrote the piece that `gsub!` the project's content was editing a local variable, not the new project's content property :stuck_out_tongue: 

Also refactored a couple project files.

