### PR TITLE
Delete button no longer show up for admin if data sets are in project

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -99,7 +99,8 @@ module ApplicationHelper
 
     case obj
     when Project
-      @cur_user.try(:admin) || (obj.owner == @cur_user && obj.data_sets.count == 0)
+      (@cur_user.try(:admin) || obj.owner == @cur_user) &&
+        obj.data_sets.count == 0
     when User, Tutorial, News
       @cur_user.try(:admin)
     when DataSet, Visualization


### PR DESCRIPTION
Addresses #1912 

Admin used to have the `Delete` button show up despite not being able to actually delete a project with data sets.  Fixed now.