### PR TITLE
Removed media block from project's vis pages

### DIFF
--- a/app/views/visualizations/displayVis.html.erb
+++ b/app/views/visualizations/displayVis.html.erb
@@ -72,13 +72,3 @@
     </div>
   </div>
 </div>
-<div class="row">
-  <% if @datasets.count == 1 %>
-    <div class="col-md-4">
-      <%@data_set = @datasets.first%>
-      <%=render layout: "shared/box", locals: {title: 'Media', width: '12', unique_id: 'media', should_hide: false} do %>
-        <%=render "shared/media_objects_view", {type: 'data_set', object: @data_set} %>
-      <%end%>
-    </div>
-  <%end%>
-</div>

--- a/test/integration/clone_project_test.rb
+++ b/test/integration/clone_project_test.rb
@@ -38,12 +38,6 @@ class CloneProjectTest < ActionDispatch::IntegrationTest
     set_cell(0, 47)
     find('#edit_table_save_2').click
 
-    assert page.has_content?('I Like Clones'), 'Save should succeed'
-    img_path = Rails.root.join('test', 'CSVs', 'nerdboy.jpg')
-    page.execute_script "$('#upload').show()"
-    find('.upload_media form').attach_file('upload', img_path)
-    assert page.has_content?('nerdboy.jpg'), 'File should be in list'
-
     click_on 'Das Cloning Projekt'
     img_path = Rails.root.join('test', 'CSVs', 'test.pdf')
     page.execute_script "$('#upload').show()"

--- a/test/integration/clone_project_test.rb
+++ b/test/integration/clone_project_test.rb
@@ -57,7 +57,6 @@ class CloneProjectTest < ActionDispatch::IntegrationTest
     find('#project_name').set('Cloned with Data')
     click_on 'Clone Project'
 
-    assert page.has_content?('nerdboy.jpg'), 'File should be in list'
     assert page.has_content?('test.pdf'), 'File should be in list'
     assert page.has_content?('I Like Clones'), 'Dataset should be in list'
 


### PR DESCRIPTION
When you click an individual data set in a project, the media block appears on the vis's page. it doesn't make sense to have that there since it does not appear when you are visualizing all data sets.

The media block still appears for saved visualizations, though.

Addresses #1829.