### PR TITLE
Fixed admin liked proj page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -86,6 +86,9 @@ module ApplicationHelper
 
     case obj
     when Project, Tutorial
+      if obj.owner.nil?
+        return false
+      end
       (obj.owner.id == @cur_user.try(:id)) || @cur_user.try(:admin)
     else
       false


### PR DESCRIPTION
Previously, the user page worked as intended for non-admins: clicking the "Liked Proj" tab and "My Projects" tab worked, and you were free to roam amongst them.  However, we were getting a 500 error crash for admins.

Turns out it's because admins have the ability to hide anyone's project, and if that project no longer has an owner, you'll crash when checking that owner's ID in the `can_hide?` method of `application_helper.rb`.

Addresses #1795.

:large_blue_circle: :palm_tree: :sunrise: 