### PR TITLE
allow data_set visualizations to be embedded too

### DIFF
--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -4,7 +4,7 @@ class VisualizationsController < ApplicationController
 
   skip_before_filter :authorize, only: [:show, :displayVis, :index, :embedVis]
 
-  after_action :allow_iframe, only: [:show]
+  after_action :allow_iframe, only: [:show, :displayVis]
 
   # GET /visualizations
   # GET /visualizations.json


### PR DESCRIPTION
this makes it possible to embed URLs like: 
/projects/[projectNum]/data_sets/[dataSetIdList]?embed=true

Being able to embed those URLs is useful so I can make a tool which filters lists of data_sets for the user and shows the default visualization of this filtered set of data_sets.