### PR TITLE
Fixed check-all bug in table for visible fields

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/table.coffee
+++ b/app/assets/javascripts/visualizations/highvis/table.coffee
@@ -61,7 +61,7 @@ $ ->
 
       start: ->
         # Make table visible? (or something)
-        ($ '#' + @canvas).show()
+        $('#' + @canvas).show()
 
         # Calls update
         super()
@@ -69,8 +69,8 @@ $ ->
       # Gets called when the controls are clicked and at start
       update: ->
         # Updates controls by default
-        ($ '#' + @canvas).html('')
-        ($ '#' + @canvas).append '<table id="data_table" class="table table-striped"></table>'
+        $('#' + @canvas).html('')
+        $('#' + @canvas).append '<table id="data_table" class="table table-striped"></table>'
 
         # Build the headers for the table
         headers = for field in data.fields
@@ -125,15 +125,15 @@ $ ->
             }
 
         # Add the nav bar
-        ($ '#table_canvas').append '<div id="toolbar_bottom"></div>'
+        $('#table_canvas').append '<div id="toolbar_bottom"></div>'
 
         # Build the grid
         @table = jQuery("#data_table").jqGrid({
           colNames: headers
           colModel: columns
           datatype: 'local'
-          height: ($ '#' + @canvas).height() - @TOOLBAR_HEIGHT_OFFSET
-          width: ($ '#' + @canvas).width()
+          height: $('#' + @canvas).height() - @TOOLBAR_HEIGHT_OFFSET
+          width: $('#' + @canvas).width()
           gridview: true
           caption: ""
           data: rows
@@ -155,7 +155,7 @@ $ ->
           else
             @table.showCol(col.name)
 
-        ($ '#data_table').setGridWidth(($ '#' + @canvas).width())
+        $('#data_table').setGridWidth($('#' + @canvas).width())
 
         # Add a refresh button and enable the search bar
         @table.jqGrid('navGrid','#toolbar_bottom',{ del:false, add:false, edit:false, search:false })
@@ -200,7 +200,7 @@ $ ->
       resize: (newWidth, newHeight, aniLength) ->
         # In the case that this was called by the hide button, this gets called a second time
         # needlessly, but doesn't effect the overall performance
-        ($ '#data_table').setGridWidth(newWidth)
+        $('#data_table').setGridWidth(newWidth)
 
       drawControls: ->
         super()
@@ -282,7 +282,7 @@ $ ->
           <div class='inner_control_div'>
             <div class='checkbox all-y-fields'>
               <label class='all-y'>
-                <input id='select-all-y' type='checkbox'> #Select All </input>
+                <input id='select-all-y' type='checkbox'> #Check All </input>
               </label>
             </div>
           </div>
@@ -303,45 +303,45 @@ $ ->
         c += "</div></div>"
 
         # Write HTML
-        ($ '#controldiv').append c
+        $('#controldiv').append c
 
         if checked
-          ($ '#select-all-y').prop('checked', true)
+          $('#select-all-y').prop('checked', true)
 
-        ($ '.y_axis_input').click (e) =>
+        $('.y_axis_input').click (e) =>
           index = Number e.target.value
           if index in @configs.tableFields
             arrayRemove(@configs.tableFields, index)
           else
             @configs.tableFields.push(index)
           if yFields.length == @configs.tableField
-            ($ '#select-all-y').prop('checked', true)
+            $('#select-all-y').prop('checked', true)
           else
-            ($ '#select-all-y').prop('checked', false)
+            $('#select-all-y').prop('checked', false)
 
           @delayedUpdate()
 
         # Set up accordion
         globals.configs.yAxisOpen ?= 0
 
-        ($ '#yAxisControl').accordion
+        $('#yAxisControl').accordion
           collapsible:true
           active:globals.configs.yAxisOpen
 
-        ($ '#yAxisControl > h3').click ->
+        $('#yAxisControl > h3').click ->
           globals.configs.yAxisOpen = (globals.configs.yAxisOpen + 1) % 2
 
-        ($ '#select-all-y').click =>
+        $('#select-all-y').click =>
           yFields = (i for f, i in data.fields when i isnt data.COMBINED_FIELD)
 
-          if yFields.length != @configs.tableFields.length
-            ($ '#yAxisControl').find('.y_axis_input').each (i,j) ->
-              ($ j).prop('checked', true)
+          if $('#select-all-y').is(":checked")
+            $('#yAxisControl').find('.y_axis_input').each (i,j) ->
+              $(j).prop('checked', true)
             @configs.tableFields = yFields
           else
             @configs.tableFields = []
-            ($ '#yAxisControl').find('.y_axis_input').each (i,j) ->
-              ($ j).prop('checked', false)
+            $('#yAxisControl').find('.y_axis_input').each (i,j) ->
+              $(j).prop('checked', false)
           @delayedUpdate()
 
     globals.table = new Table "table_canvas"

--- a/app/assets/javascripts/visualizations/highvis/table.coffee
+++ b/app/assets/javascripts/visualizations/highvis/table.coffee
@@ -317,13 +317,8 @@ $ ->
 
           if yFields.length == @configs.tableFields.length
             $('#select-all-y').prop("checked", true)
-            $('#select-all-y').prop("indeterminate", false)
-          else if @configs.tableFields.length > 0
-            $('#select-all-y').prop("checked", false)
-            $('#select-all-y').prop("indeterminate", true)
           else
             $('#select-all-y').prop("checked", false)
-            $('#select-all-y').prop("indeterminate", false)
 
           @delayedUpdate()
 

--- a/app/assets/javascripts/visualizations/highvis/table.coffee
+++ b/app/assets/javascripts/visualizations/highvis/table.coffee
@@ -314,10 +314,16 @@ $ ->
             arrayRemove(@configs.tableFields, index)
           else
             @configs.tableFields.push(index)
-          if yFields.length == @configs.tableField
-            $('#select-all-y').prop('checked', true)
+
+          if yFields.length == @configs.tableFields.length
+            $('#select-all-y').prop("checked", true)
+            $('#select-all-y').prop("indeterminate", false)
+          else if @configs.tableFields.length > 0
+            $('#select-all-y').prop("checked", false)
+            $('#select-all-y').prop("indeterminate", true)
           else
-            $('#select-all-y').prop('checked', false)
+            $('#select-all-y').prop("checked", false)
+            $('#select-all-y').prop("indeterminate", false)
 
           @delayedUpdate()
 
@@ -332,16 +338,18 @@ $ ->
           globals.configs.yAxisOpen = (globals.configs.yAxisOpen + 1) % 2
 
         $('#select-all-y').click =>
-          yFields = (i for f, i in data.fields when i isnt data.COMBINED_FIELD)
+          selFields =
+            (i for f, i in data.fields when i isnt data.COMBINED_FIELD)
 
           if $('#select-all-y').is(":checked")
             $('#yAxisControl').find('.y_axis_input').each (i,j) ->
               $(j).prop('checked', true)
-            @configs.tableFields = yFields
+            @configs.tableFields = selFields
           else
             @configs.tableFields = []
             $('#yAxisControl').find('.y_axis_input').each (i,j) ->
               $(j).prop('checked', false)
+
           @delayedUpdate()
 
     globals.table = new Table "table_canvas"


### PR DESCRIPTION
Addresses #1980 

The problems were:
- the code was checking the length of all fields versus selected fields instead of very simply checking if the "#Check All" box was selected or not, leading to the error described in the issue
- yFields was improperly being modified in the click event of the "#Check All" box - switched it to a temp variable called selFields

Additionally:
- Changed some "($ " to "$("
- Changed the name of the box to "#Check All" instead of "#Select All" to be consistent with the groups check-all box