### PR TITLE
pointer when hovering above get or post in api docs

### DIFF
--- a/app/assets/stylesheets/api.css.scss
+++ b/app/assets/stylesheets/api.css.scss
@@ -4,6 +4,7 @@ body[data-page-name="home/api_v1"] {
     background-color: green;
     color: white;
     width: 5em;
+    cursor: pointer;
     text-align: center;
   }
 
@@ -12,6 +13,7 @@ body[data-page-name="home/api_v1"] {
     background-color: blue;
     color: white;
     width: 5em;
+    cursor: pointer;
     text-align: center;
   }
 


### PR DESCRIPTION
Replaced text cursor with a pointer to indicate you can expand api docs by clicking on get or post.
#1995 