### PR TITLE
Adding basic kml layer support

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -257,8 +257,8 @@ $ ->
         @drawControls()
         
         ctaLayer = new google.maps.KmlLayer({url: window.kml})
-       
-        ctaLayer.setMap(@gmap);
+        ctaLayer.setMap(@gmap)
+
         finalInit = =>
           @configs.zoomLevel = @gmap.getZoom()
           google.maps.event.addListener @gmap, "zoom_changed", =>

--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -255,7 +255,10 @@ $ ->
           @gmap.fitBounds(latlngbounds)
 
         @drawControls()
-
+        
+        ctaLayer = new google.maps.KmlLayer({url: window.kml})
+       
+        ctaLayer.setMap(@gmap);
         finalInit = =>
           @configs.zoomLevel = @gmap.getZoom()
           google.maps.event.addListener @gmap, "zoom_changed", =>

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -399,12 +399,12 @@ class ProjectsController < ApplicationController
                                      :is_template, :featured_media_id, :hidden,
                                      :featured_at, :lock, :curated,
                                      :curated_at, :updated_at, :default_vis,
-                                     :precision, :globals)
+                                     :precision, :globals, :kml_metadata)
     end
 
     params[:project].permit(:content, :title, :user_id, :filter, :hidden,
                             :cloned_from, :has_fields, :featured_media_id,
                             :lock, :updated_at, :default_vis, :precision,
-                            :globals)
+                            :globals, :kml_metadata)
   end
 end

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -31,6 +31,14 @@
       </div>
 
       <div class="form-group">
+        <strong>Map Layer</strong>
+        <div>
+          <%=f.text_field(:kml_metadata, value: @project.kml_metadata) %>
+        </div>
+        <span class="help-block">Defines a layer to be displayed ontop of the map visualization.</span>
+      </div>
+      
+      <div class="form-group">
         <div class="checkbox">
           <div class="checkbox checkbox-inner">
             <%= f.check_box :lock %><strong> <i class="fa fa-lock"></i> Lock Project</strong>

--- a/app/views/visualizations/displayVis.html.erb
+++ b/app/views/visualizations/displayVis.html.erb
@@ -1,4 +1,5 @@
 <script>
+  window.kml = "<%= @project.kml_metadata %>";
   window.data = <%= raw @data.to_json %>;
   window.icons = { 'Map_dark': "<%= path_to_image('vis_map_dark.png')%>",
                    'Map_light': "<%= path_to_image('vis_map_light.png')%>",

--- a/db/migrate/20150225125927_add_kml_to_project.rb
+++ b/db/migrate/20150225125927_add_kml_to_project.rb
@@ -1,0 +1,5 @@
+class AddKmlToProject < ActiveRecord::Migration
+  def change
+    add_column :projects, :kml_metadata, :text, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141015152508) do
+ActiveRecord::Schema.define(version: 20150225125927) do
 
   create_table "contrib_keys", force: true do |t|
     t.string   "name",       null: false
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 20141015152508) do
     t.text     "default_vis"
     t.integer  "precision",                     default: 4
     t.text     "globals"
+    t.text     "kml_metadata"
   end
 
   create_table "tutorials", force: true do |t|


### PR DESCRIPTION
A URL to a KMLl file can be given to a project in the project/edit page. 
The map will then show that layer independent of any data that the user uploads.

There is not a test written for this yet, could @JKinsman or @bdonald25 please figure out a functional test for this, simple as setting the value and making sure its set. 

A sample kml file can be found at http://edna.usgs.gov/watersheds/sheds/USWatersheds/USWatersheds.kml