### PR TITLE
Navigation confirmation for leaving project page without saving description

### DIFF
--- a/app/assets/javascripts/projects/show.js.coffee
+++ b/app/assets/javascripts/projects/show.js.coffee
@@ -299,6 +299,8 @@ IS.onReady "projects/show", ->
   # Enable the navigation pop-up if the user is editing the description
   $('#content-edit-btn').click ->
     confirm_nav = true
+  $('#add-content-image').click ->
+    confirm_nav = true
 
   # Pop up a warning if the project description has changed
   $(window).on 'beforeunload', ->

--- a/app/assets/javascripts/projects/show.js.coffee
+++ b/app/assets/javascripts/projects/show.js.coffee
@@ -276,39 +276,3 @@ IS.onReady "projects/show", ->
   $('#print').click (e) ->
     e.preventDefault()
     window.print()
-
-  ###
-  # Track whether the user is leaving the page with unsaved content
-  ###
-  # Initialize a variable that determines whether or not to ask
-  # for confirmation to leave the page, and keep track of the
-  # current description content
-  confirm_nav = false
-  if $('.summernote').code()
-    desc = $('.summernote').code().trim()
-  else
-    desc = ''
-
-  # Disable the navigation pop-up if the user is saving or canceling
-  $('#content-save-btn').click ->
-    confirm_nav = false
-    true
-  $('#content-cancel-btn').click ->
-    confirm_nav = false
-    true
-  # Enable the navigation pop-up if the user is editing the description
-  $('#content-edit-btn').click ->
-    confirm_nav = true
-  $('#add-content-image').click ->
-    confirm_nav = true
-
-  # Pop up a warning if the project description has changed
-  $(window).on 'beforeunload', ->
-    if $('.summernote').code()
-      desc_new = $('.summernote').code().trim()
-    else
-      desc_new = ''
-    if (confirm_nav && (desc_new != desc))
-      return "You have attempted to leave this page.  If you have made any " +
-        "changes to the project description without clicking the Save " +
-        "button, your changes will be lost."

--- a/app/assets/javascripts/projects/show.js.coffee
+++ b/app/assets/javascripts/projects/show.js.coffee
@@ -284,7 +284,10 @@ IS.onReady "projects/show", ->
   # for confirmation to leave the page, and keep track of the
   # current description content
   confirm_nav = false
-  desc = $('.summernote').code().trim()
+  if $('.summernote').code()
+    desc = $('.summernote').code().trim()
+  else
+    desc = ''
 
   # Disable the navigation pop-up if the user is saving or canceling
   $('#content-save-btn').click ->
@@ -299,7 +302,10 @@ IS.onReady "projects/show", ->
 
   # Pop up a warning if the project description has changed
   $(window).on 'beforeunload', ->
-    desc_new = $('.summernote').code().trim()
+    if $('.summernote').code()
+      desc_new = $('.summernote').code().trim()
+    else
+      desc_new = ''
     if (confirm_nav && (desc_new != desc))
       return "You have attempted to leave this page.  If you have made any " +
         "changes to the project description without clicking the Save " +

--- a/app/assets/javascripts/projects/show.js.coffee
+++ b/app/assets/javascripts/projects/show.js.coffee
@@ -1,38 +1,23 @@
 IS.onReady "projects/show", ->
 
   # Initializes the dropdown lightbox for google drive upload
-  ($ '#google_doc').click ->
-    ($ '#doc_box').modal()
+  $('#google_doc').click ->
+    $('#doc_box').modal()
     false
 
-  ($ '#cancel_doc').click (e) ->
+  $('#cancel_doc').click (e) ->
     e.preventDefault()
-    ($ '#doc_box').modal 'hide'
+    $('#doc_box').modal 'hide'
 
-  ($ '#doc_box').on 'hidden', ->
-    ($ '#doc_box').hide()
-
-  ###
-  # Track whether the user is leaving the page with unsaved content
-  ###
-
-  # Keep track of the current desciption content
-  desc_on_load = ($ '#content-viewer').text().trim()
-
-  # Pop-up a warning if the project description has changed
-  ($ window).on 'beforeunload', ->
-    desc_on_unload = ($ '.summernote').code().trim()
-    if (desc_on_unload != desc_on_load)
-      return "You have attempted to leave this page.  If you have made any " +
-        "changes to the description without clicking the Save button, your " +
-        "changes will be lost."
+  $('#doc_box').on 'hidden', ->
+    $('#doc_box').hide()
 
   ##
   # Does the liking and unliking when the thumbs-up icon is clicked
   ##
-  ($ '.liked_status').click ->
-    root = ($ ".likes")
-    was_liked = ($ @).hasClass('active')
+  $('.liked_status').click ->
+    root = $(".likes")
+    was_liked = $(@).hasClass('active')
 
     $.ajax
       url: "/projects/#{ root.attr 'data-project_id' }/updateLikedStatus"
@@ -41,140 +26,140 @@ IS.onReady "projects/show", ->
       success: (resp) ->
         root.find('.like_display').html resp['update']
       error: (resp) =>
-        ($ @).errorFlash()
+        $(@).errorFlash()
         if was_liked
-          ($ @).addClass('active')
+          $(@).addClass('active')
         else
-          ($ @).removeClass('active')
+          $(@).removeClass('active')
 
   ###
   # Controls for uploading a file.
   ###
   # Displays the upload csv and upload google doc lightboxes
-  ($ '#upload_datafile').click ->
-    ($ '#datafile_input').click()
+  $('#upload_datafile').click ->
+    $('#datafile_input').click()
     false
 
   # Auto-submit the file upload form when user hits the open button.
-  ($ '#datafile_input').change ->
-    ($ '#datafile_form').submit()
+  $('#datafile_input').change ->
+    $('#datafile_form').submit()
 
 
   ###
   # Controls for uploading template file.
   ###
-  ($ '#template_file_upload').click ->
-    ($ '#template_file_input').click()
+  $('#template_file_upload').click ->
+    $('#template_file_input').click()
     false
-  ($ '#template_file_input').change ->
-    ($ '#template_file_form').submit()
+  $('#template_file_input').change ->
+    $('#template_file_form').submit()
 
   ###
   # Controls for Data Sets box
   ###
   # Takes all sessions that are checked, appends its id to the url and
   # redirects the user to the view sessions page (Vis page)
-  ($ '#vis_button').click (e) ->
-    targets = ($ document).find(".dataset .ds_selector input:checked")
+  $('#vis_button').click (e) ->
+    targets = $(document).find(".dataset .ds_selector input:checked")
     ds_list = (get_ds_id t for t in targets)
-    window.location = ($ this).attr("data-href") + ds_list
+    window.location = $(this).attr("data-href") + ds_list
 
-  ($ '#export_button').click (e) ->
-    ($ '#export_modal').modal('show')
+  $('#export_button').click (e) ->
+    $('#export_modal').modal('show')
 
-  ($ '#export_individual_button').click (e) ->
-    ($ '#export_modal').modal('hide')
-    targets = ($ document).find(".dataset .ds_selector input:checked")
-    ds_list = (get_ds_id t for t in targets)
-
-    if ds_list.length is 0
-      alert "No data sets selected for Export. Select at least 1 and try again."
-    else
-      window.location = ($ this).attr("data-href") + ds_list
-
-  ($ '#export_concatenated_button').click (e) ->
-    ($ '#export_modal').modal('hide')
-    targets = ($ document).find(".dataset .ds_selector input:checked")
+  $('#export_individual_button').click (e) ->
+    $('#export_modal').modal('hide')
+    targets = $(document).find(".dataset .ds_selector input:checked")
     ds_list = (get_ds_id t for t in targets)
 
     if ds_list.length is 0
       alert "No data sets selected for Export. Select at least 1 and try again."
     else
-      window.location = ($ this).attr("data-href") + ds_list
+      window.location = $(this).attr("data-href") + ds_list
+
+  $('#export_concatenated_button').click (e) ->
+    $('#export_modal').modal('hide')
+    targets = $(document).find(".dataset .ds_selector input:checked")
+    ds_list = (get_ds_id t for t in targets)
+
+    if ds_list.length is 0
+      alert "No data sets selected for Export. Select at least 1 and try again."
+    else
+      window.location = $(this).attr("data-href") + ds_list
 
   # get the session number for viewing vises
   get_ds_id = (t) ->
-    ds_id = ($ t).attr 'id'
+    ds_id = $(t).attr 'id'
     ds_id = ds_id.split '_'
     ds_id[1]
 
   #Select all/none check box in the data sets box
-  ($ "a#check_all").click ->
-    root = ($ '#dataset_table')
+  $("a#check_all").click ->
+    root = $('#dataset_table')
     root.find("[id^=ds_]").each (i,j) ->
-      ($ j).prop("checked",true)
-    ($ '#vis_button').prop("disabled",false)
-    ($ '#export_button').prop("disabled",false)
+      $(j).prop("checked",true)
+    $('#vis_button').prop("disabled",false)
+    $('#export_button').prop("disabled",false)
 
-  ($ "a#uncheck_all").click ->
-    root = ($ '#dataset_table')
+  $("a#uncheck_all").click ->
+    root = $('#dataset_table')
     root.find("[id^=ds_]").each (i,j) ->
-      ($ j).prop("checked",false)
-    ($ '#vis_button').prop("disabled",true)
-    ($ '#export_button').prop("disabled",true)
+      $(j).prop("checked",false)
+    $('#vis_button').prop("disabled",true)
+    $('#export_button').prop("disabled",true)
 
-  ($ "a#check_mine").click ->
-    root = ($ '#dataset_table')
+  $("a#check_mine").click ->
+    root = $('#dataset_table')
     root.find("[id^=ds_]").each (i,j) ->
-      ($ j).prop("checked",false)
+      $(j).prop("checked",false)
     root.find(".mine").each (i,j) ->
-      ($ j).prop("checked",true)
+      $(j).prop("checked",true)
     if root.find(".mine").length isnt 0
-      ($ '#vis_button').prop("disabled",false)
-      ($ '#export_button').prop("disabled",false)
+      $('#vis_button').prop("disabled",false)
+      $('#export_button').prop("disabled",false)
     else
-      ($ '#vis_button').prop("disabled",true)
-      ($ '#export_button').prop("disabled",true)
-  ($ "a.check_id").click ->
-    root = ($ '#dataset_table')
-    ($ '#vis_button').prop("disabled",true)
-    ($ '#export_button').prop("disabled",true)
+      $('#vis_button').prop("disabled",true)
+      $('#export_button').prop("disabled",true)
+  $("a.check_id").click ->
+    root = $('#dataset_table')
+    $('#vis_button').prop("disabled",true)
+    $('#export_button').prop("disabled",true)
     root.find("[id^=ds_]").each (i,j) ->
-      ($ j).prop("checked",false)
+      $(j).prop("checked",false)
     root.find('tr').each (i,j) =>
-      if ($ j).find('.key').attr('title') is ($ this).attr('m-title')
-        ($ j).find("[id^=ds_]").prop("checked",true)
-        ($ '#vis_button').prop("disabled",false)
-        ($ '#export_button').prop("disabled",false)
+      if $(j).find('.key').attr('title') is $(this).attr('m-title')
+        $(j).find("[id^=ds_]").prop("checked",true)
+        $('#vis_button').prop("disabled",false)
+        $('#export_button').prop("disabled",false)
   #Turn off visualize button on page load, and when nothings checked
   check_for_selection = ->
     should_disable = true
-    ($ document).find("[id^=ds_]").each (i,j) ->
-      if(($ j).is(":checked"))
+    $(document).find("[id^=ds_]").each (i,j) ->
+      if($(j).is(":checked"))
         should_disable = false
       else
-        ($ '#check_selector').prop("checked",false)
-        ($ '#export_button').prop("disabled",false)
-      ($ '#vis_button').prop("disabled", should_disable)
-      ($ '#export_button').prop("disabled", should_disable)
+        $('#check_selector').prop("checked",false)
+        $('#export_button').prop("disabled",false)
+      $('#vis_button').prop("disabled", should_disable)
+      $('#export_button').prop("disabled", should_disable)
 
   check_for_selection()
 
   #Add click events to all check boxes in the data_sets box
-  ($ document).find("[id^=ds_]").each (i,j) ->
-    ($ j).click check_for_selection
+  $(document).find("[id^=ds_]").each (i,j) ->
+    $(j).click check_for_selection
 
   # delete data sets
 
-  ($ 'a.data_set_delete').click (e) ->
+  $('a.data_set_delete').click (e) ->
     e.preventDefault()
 
-    url = ($ @).attr('href')
-    row = ($ @).parents('tr')
+    url = $(@).attr('href')
+    row = $(@).parents('tr')
     p_id = url.split '/'
     p_id = p_id[ p_id.length - 1 ]
 
-    if helpers.confirm_delete ($ @).attr('name')
+    if helpers.confirm_delete $(@).attr('name')
       $.ajax
         url: url
         type: "delete"
@@ -190,7 +175,7 @@ IS.onReady "projects/show", ->
           response = $.parseJSON msg['responseText']
           error_message = response.errors.join "</p><p>"
 
-          ($ '.container.mainContent').find('p').before """
+          $('.container.mainContent').find('p').before """
             <div class="alert alert-danger fade in">
               <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
               <h4>Error Deleting Data Set:</h4>
@@ -201,18 +186,18 @@ IS.onReady "projects/show", ->
               </p>
             </div>"""
 
-          ($ '.error_dismiss').click ->
-            ($ '.alert').alert 'close'
+          $('.error_dismiss').click ->
+            $('.alert').alert 'close'
 
-          ($ '.error_bind').click ->
-            ($ '.error_bind').button 'loading'
+          $('.error_bind').click ->
+            $('.error_bind').button 'loading'
             $.ajax
               url: url
               type: 'DELETE'
               dataType: "json"
               success: ->
-                ($ '.error_bind').button 'reset'
-                ($ '.alert').alert 'close'
+                $('.error_bind').button 'reset'
+                $('.alert').alert 'close'
                 recolored = false
                 tbody = row.parents('tbody')
                 row.delete_row ->
@@ -220,11 +205,11 @@ IS.onReady "projects/show", ->
                   tbody.recolor_rows(recolored)
                   recolored = true
               error: (msg) ->
-                ($ '.error_bind').button 'reset'
+                $('.error_bind').button 'reset'
 
   # delete visualizations
 
-  ($ 'a.viz_delete').click (e) ->
+  $('a.viz_delete').click (e) ->
     e.preventDefault()
 
     url = e.target.href
@@ -232,15 +217,15 @@ IS.onReady "projects/show", ->
     p_id = url.split '/'
     p_id = p_id[ p_id.length - 1 ]
 
-    if helpers.confirm_delete ($ @).attr('name')
+    if helpers.confirm_delete $(@).attr('name')
       $.ajax
-        url: ($ @).attr('href')
+        url: $(@).attr('href')
         type: 'DELETE'
         dataType: "json"
         beforeSend: ->
         success: =>
           recolored = false
-          row = ($ @).parents('tr')
+          row = $(@).parents('tr')
           tbody = row.parents('tbody')
           row.delete_row ->
             row.remove()
@@ -250,7 +235,7 @@ IS.onReady "projects/show", ->
           response = $.parseJSON msg['responseText']
           error_message = response.errors.join "</p><p>"
 
-          ($ '.container.mainContent').find('p').before """
+          $('.container.mainContent').find('p').before """
             <div class="alert alert-danger fade in">
               <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
               <h4>Error Deleting Vis:</h4>
@@ -261,39 +246,61 @@ IS.onReady "projects/show", ->
               </p>
             </div>"""
 
-          ($ '.error_dismiss').click ->
-            ($ '.alert').alert 'close'
+          $('.error_dismiss').click ->
+            $('.alert').alert 'close'
 
-          ($ '.error_bind').click ->
-            ($ '.error_bind').button 'loading'
+          $('.error_bind').click ->
+            $('.error_bind').button 'loading'
 
             $.ajax
               url: url
               type: 'DELETE'
               dataType: "json"
               success: =>
-                ($ '.error_bind').button 'reset'
-                ($ '.alert').alert 'close'
+                $('.error_bind').button 'reset'
+                $('.alert').alert 'close'
                 recolored = false
-                row = ($ @).parents('tr')
+                row = $(@).parents('tr')
                 tbody = row.parents('tbody')
                 row.delete_row ->
                   row.remove()
                   tbody.recolor_rows(recolored)
                   recolored = true
               error: (msg) ->
-                ($ '.error_bind').button 'reset'
+                $('.error_bind').button 'reset'
 
 
   ###
   # Print for page
   ###
-  ($ '#print').click (e) ->
+  $('#print').click (e) ->
     e.preventDefault()
     window.print()
-  ($ '#content-edit-btn').click (e) ->
-    ($ '#content-partial').css('overflow-y': 'hidden')
-  ($ '#content-cancel-btn').click (e) ->
-    ($ '#content-partial').css('overflow-y': 'scroll')
-  ($ '#content-save-btn').click (e) ->
-    ($ '#content-partial').css('overflow-y': 'scroll')
+
+  ###
+  # Track whether the user is leaving the page with unsaved content
+  ###
+  # Initialize a variable that determines whether or not to ask
+  # for confirmation to leave the page, and keep track of the
+  # current description content
+  confirm_nav = false
+  desc = $('.summernote').code().trim()
+
+  # Disable the navigation pop-up if the user is saving or canceling
+  $('#content-save-btn').click ->
+    confirm_nav = false
+    true
+  $('#content-cancel-btn').click ->
+    confirm_nav = false
+    true
+  # Enable the navigation pop-up if the user is editing the description
+  $('#content-edit-btn').click ->
+    confirm_nav = true
+
+  # Pop up a warning if the project description has changed
+  $(window).on 'beforeunload', ->
+    desc_new = $('.summernote').code().trim()
+    if (confirm_nav && (desc_new != desc))
+      return "You have attempted to leave this page.  If you have made any " +
+        "changes to the project description without clicking the Save " +
+        "button, your changes will be lost."

--- a/app/assets/javascripts/projects/show.js.coffee
+++ b/app/assets/javascripts/projects/show.js.coffee
@@ -12,8 +12,24 @@ IS.onReady "projects/show", ->
   ($ '#doc_box').on 'hidden', ->
     ($ '#doc_box').hide()
 
+  ###
+  # Track whether the user is leaving the page with unsaved content
+  ###
 
+  # Keep track of the current desciption content
+  desc_on_load = ($ '#content-viewer').text().trim()
+
+  # Pop-up a warning if the project description has changed
+  ($ window).on 'beforeunload', ->
+    desc_on_unload = ($ '.summernote').code().trim()
+    if (desc_on_unload != desc_on_load)
+      return "You have attempted to leave this page.  If you have made any " +
+        "changes to the description without clicking the Save button, your " +
+        "changes will be lost."
+
+  ##
   # Does the liking and unliking when the thumbs-up icon is clicked
+  ##
   ($ '.liked_status').click ->
     root = ($ ".likes")
     was_liked = ($ @).hasClass('active')
@@ -34,7 +50,7 @@ IS.onReady "projects/show", ->
   ###
   # Controls for uploading a file.
   ###
-  # This is black magic that displays the upload csv and upload google doc lightboxes
+  # Displays the upload csv and upload google doc lightboxes
   ($ '#upload_datafile').click ->
     ($ '#datafile_input').click()
     false

--- a/app/assets/javascripts/shared/confirm_nav.js.coffee
+++ b/app/assets/javascripts/shared/confirm_nav.js.coffee
@@ -3,35 +3,30 @@ setupNavConfirmation = () ->
   # for confirmation to leave the page, and keep track of the
   # current description content
   confirm_nav = false
+  desc = ''
   if $('.summernote').code()
     desc = $('.summernote').code().trim()
-  else
-    desc = ''
 
   # Disable the navigation pop-up if the user is saving or canceling
-  if $('#content-save-btn')?
-    $('#content-save-btn').click ->
-      confirm_nav = false
-      true
-  if $('#content-cancel-btn')?
-    $('#content-cancel-btn').click ->
-      confirm_nav = false
-      true
+  $('#content-save-btn').click ->
+    confirm_nav = false
+    return true
+  $('#content-cancel-btn').click ->
+    confirm_nav = false
+    return true
 
   # Enable the navigation pop-up if the user is editing the description
-  if $('#content-edit-btn')?
-    $('#content-edit-btn').click ->
-      confirm_nav = true
-  if $('#add-content-image')?
-    $('#add-content-image').click ->
-      confirm_nav = true
+  $('#content-edit-btn').click ->
+    confirm_nav = true
+  $('#add-content-image').click ->
+    confirm_nav = true
 
   # Pop up a warning if the description has changed
   $(window).on 'beforeunload', ->
+    desc_new = ''
     if $('.summernote').code()
       desc_new = $('.summernote').code().trim()
-    else
-      desc_new = ''
+
     if (confirm_nav && (desc_new != desc))
       return "You have attempted to leave this page. If you have made any " +
         "changes to the project description without clicking the Save " +

--- a/app/assets/javascripts/shared/confirm_nav.js.coffee
+++ b/app/assets/javascripts/shared/confirm_nav.js.coffee
@@ -1,0 +1,42 @@
+setupNavConfirmation = () ->
+  # Initialize a variable that determines whether or not to ask
+  # for confirmation to leave the page, and keep track of the
+  # current description content
+  confirm_nav = false
+  if $('.summernote').code()
+    desc = $('.summernote').code().trim()
+  else
+    desc = ''
+
+  # Disable the navigation pop-up if the user is saving or canceling
+  if $('#content-save-btn')?
+    $('#content-save-btn').click ->
+      confirm_nav = false
+      true
+  if $('#content-cancel-btn')?
+    $('#content-cancel-btn').click ->
+      confirm_nav = false
+      true
+
+  # Enable the navigation pop-up if the user is editing the description
+  if $('#content-edit-btn')?
+    $('#content-edit-btn').click ->
+      confirm_nav = true
+  if $('#add-content-image')?
+    $('#add-content-image').click ->
+      confirm_nav = true
+
+  # Pop up a warning if the description has changed
+  $(window).on 'beforeunload', ->
+    if $('.summernote').code()
+      desc_new = $('.summernote').code().trim()
+    else
+      desc_new = ''
+    if (confirm_nav && (desc_new != desc))
+      return "You have attempted to leave this page. If you have made any " +
+        "changes to the project description without clicking the Save " +
+        "button, your changes will be lost."
+
+$ ->
+  if $('.summernote').length
+    setupNavConfirmation()

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -88,3 +88,8 @@ slickgrid_project_no_latlon:
 slickgrid_oops:
   title: slickgrid_oops
   user: nixon
+
+description_test:
+  title: Goat
+  user: kate
+  content: Description Test

--- a/test/integration/edit_proj_desc_test.rb
+++ b/test/integration/edit_proj_desc_test.rb
@@ -1,0 +1,102 @@
+require 'test_helper'
+
+class EditProjDescTest < ActionDispatch::IntegrationTest
+  include CapyHelper
+
+  self.use_transactional_fixtures = false
+
+  setup do
+    @project = projects(:description_test)
+    Capybara.current_driver = :webkit
+    Capybara.default_wait_time = 15
+  end
+
+  teardown do
+    finish
+  end
+
+  test 'nav on no desc edit' do
+    login('kcarcia@cs.uml.edu', '12345')
+    visit project_path(@project)
+    assert page.has_content?('Goat'), 'Not on project page.'
+
+    # confirm you can leave the project page
+    find('#edit-project-button').click
+    assert page.has_content?('Back to Project'), 'Not on edit page.'
+  end
+
+  test 'nav on edit desc no changes' do
+    login('kcarcia@cs.uml.edu', '12345')
+    visit project_path(@project)
+    assert page.has_content?('Goat'), 'Not on project page.'
+
+    # click the description but do not add text to it
+    find('#content-edit-btn').click
+
+    # confirm can navigate away from page
+    find('#manual_fields').click
+    assert page.has_css?('.fields_table'), 'Not on manual entry page.'
+  end
+
+  test 'nav on edit desc and cancel' do
+    login('kcarcia@cs.uml.edu', '12345')
+    visit project_path(@project)
+    assert page.has_content?('Goat'), 'Not on project page.'
+
+    # start typing a description and confirm the text exists
+    find('#content-edit-btn').click
+    find('.note-editable').set('arbitrary')
+    assert page.has_content?('arbitrary'), 'No description added.'
+
+    # cancel the description, confirm it is gone, and confirm navigation away
+    find('#content-cancel-btn').click
+    assert page.has_no_content?('aritrary'), 'Description should be gone.'
+    find('#manual_fields').click
+    assert page.has_css?('.fields_table'), 'Not on manual entry page.'
+  end
+
+  test 'nav on edit desc and save' do
+    login('kcarcia@cs.uml.edu', '12345')
+    visit project_path(@project)
+    assert page.has_content?('Goat'), 'Not on project page.'
+
+    # start typing a description and confirm the text exists
+    find('#content-edit-btn').click
+    find('.note-editable').set('more arbitrary')
+    assert page.has_content?('more arbitrary'), 'No description added.'
+
+    # save the description, confirm nav back to project with the new description
+    find('#content-save-btn').click
+    assert page.has_content?('Goat'), 'Not on project page.'
+    assert page.has_content?('more arbitrary'), 'Description not saved.'
+
+    # confirm can navigate away from project page
+    find('#edit-project-button').click
+    assert page.has_content?('Back to Project'), 'Not on edit page.'
+  end
+
+  test 'shouldnt nav on edit desc and leave' do
+    login('kcarcia@cs.uml.edu', '12345')
+    visit project_path(@project)
+    assert page.has_content?('Goat'), 'Not on project page.'
+
+    # start typing a description and confirm the text exists
+    find('#content-edit-btn').click
+    find('.note-editable').set('arbitrary wow')
+    assert page.has_content?('arbitrary wow'), 'No description added.'
+
+    # without saving, try navigating away - should be stopped by a JS pop-up
+    page.driver.browser.reject_js_confirms
+    find('#edit-project-button').click
+    assert page.has_no_content?('Back to Project'), 'Shouldnt be on edit page.'
+
+    # without saving, try refreshing - should still be stopped by JS pop-up
+    visit current_path
+    assert page.has_content?('Goat'), 'Not on project page.'
+
+    # now accept the JS navigation and confirm we left the project page
+    page.driver.browser.accept_js_confirms
+    find('#edit-project-button').click
+    assert page.has_content?('Back to Project'), 'Should be on edit page.'
+  end
+end

--- a/test/integration/edit_proj_desc_test.rb
+++ b/test/integration/edit_proj_desc_test.rb
@@ -15,10 +15,14 @@ class EditProjDescTest < ActionDispatch::IntegrationTest
     finish
   end
 
-  test 'nav on no desc edit' do
+  def login_and_nav_to_project
     login('kcarcia@cs.uml.edu', '12345')
     visit project_path(@project)
     assert page.has_content?('Goat'), 'Not on project page.'
+  end
+
+  test 'nav on no desc edit' do
+    login_and_nav_to_project
 
     # confirm you can leave the project page
     find('#edit-project-button').click
@@ -26,9 +30,7 @@ class EditProjDescTest < ActionDispatch::IntegrationTest
   end
 
   test 'nav on edit desc no changes' do
-    login('kcarcia@cs.uml.edu', '12345')
-    visit project_path(@project)
-    assert page.has_content?('Goat'), 'Not on project page.'
+    login_and_nav_to_project
 
     # click the description but do not add text to it
     find('#content-edit-btn').click
@@ -39,9 +41,7 @@ class EditProjDescTest < ActionDispatch::IntegrationTest
   end
 
   test 'nav on edit desc and cancel' do
-    login('kcarcia@cs.uml.edu', '12345')
-    visit project_path(@project)
-    assert page.has_content?('Goat'), 'Not on project page.'
+    login_and_nav_to_project
 
     # start typing a description and confirm the text exists
     find('#content-edit-btn').click
@@ -56,9 +56,7 @@ class EditProjDescTest < ActionDispatch::IntegrationTest
   end
 
   test 'nav on edit desc and save' do
-    login('kcarcia@cs.uml.edu', '12345')
-    visit project_path(@project)
-    assert page.has_content?('Goat'), 'Not on project page.'
+    login_and_nav_to_project
 
     # start typing a description and confirm the text exists
     find('#content-edit-btn').click
@@ -76,9 +74,7 @@ class EditProjDescTest < ActionDispatch::IntegrationTest
   end
 
   test 'shouldnt nav on edit desc and leave' do
-    login('kcarcia@cs.uml.edu', '12345')
-    visit project_path(@project)
-    assert page.has_content?('Goat'), 'Not on project page.'
+    login_and_nav_to_project
 
     # start typing a description and confirm the text exists
     find('#content-edit-btn').click


### PR DESCRIPTION
Addresses #1828 
Even added some tests to cover editing project descriptions and ensuring the pop-up I implemented here works as intended (that is, asking for navigation confirmation if the project description was modified, not saved/canceled, and the user tried leaving the page).