### PR TITLE
Contributor key only displays when appropriate

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -244,7 +244,7 @@
             </div>
           <% end %>
         <% else %>
-          <% if @project.has_contrib_key? and @cur_user.nil? %>
+          <% if @project.has_contrib_key? and @cur_user.nil? and @has_fields %>
             <p>Enter contributor key to submit data.</p>
             <%= form_tag '/contrib_keys/enter', method: 'post' do %>
               <div class="row" style="margin-left: 0px;" >

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -244,7 +244,7 @@
             </div>
           <% end %>
         <% else %>
-          <% if @project.has_contrib_key? %>
+          <% if @project.has_contrib_key? and @cur_user.nil? %>
             <p>Enter contributor key to submit data.</p>
             <%= form_tag '/contrib_keys/enter', method: 'post' do %>
               <div class="row" style="margin-left: 0px;" >


### PR DESCRIPTION
Addresses #1985

1. You should not be able to enter a key when you're logged in.
2. The option to enter a contributor key for non logged in users should only appear when a project has fields.