### PR TITLE
Better redirect on media delete

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -56,7 +56,7 @@ class MediaObjectsController < ApplicationController
 
       respond_to do |format|
         format.html do
-          redirect_to @media_object.parent, notice: "Deleted #{@media_object.name}"
+          redirect_to request.referer, notice: "Deleted #{@media_object.name}"
         end
         format.json { render json: {}, status: :ok }
       end

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -56,7 +56,7 @@ class MediaObjectsController < ApplicationController
 
       respond_to do |format|
         format.html do
-          redirect_to request.referer, notice: "Deleted #{@media_object.name}"
+          redirect_to :back, notice: "Deleted #{@media_object.name}"
         end
         format.json { render json: {}, status: :ok }
       end

--- a/test/functional/media_objects_controller_test.rb
+++ b/test/functional/media_objects_controller_test.rb
@@ -91,10 +91,12 @@ class MediaObjectsControllerTest < ActionController::TestCase
   end
 
   test 'should destroy media_object' do
+    request.env['HTTP_REFERER'] = request.path
+
     assert_difference('MediaObject.count', -1) do
       delete :destroy, { id: @media_object },  user_id: @nixon
+      assert_redirected_to request.env['HTTP_REFERER']
     end
-    assert_redirected_to @media_object.project
   end
 
   test 'shouldnt destroy media_object' do


### PR DESCRIPTION
Addresses #2025 

Rather than redirecting to the media_object's parent (always the project page), we now redirect back to wherever we were before.  Hooray. :camel: 