### PR TITLE
Added unit information to tooltips

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -60,9 +60,10 @@ $ ->
               str += "color:#{@series.color};margin-bottom:5px'> "
               str += "#{@series.name}</div>"
               str += "<table>"
-              str += "<tr><td>#{@key} "
+              str += "<tr><td>#{data.fields[globals.configs.fieldSelection[@x]].fieldName} "
               str += "(#{self.analysisTypeNames[self.configs.analysisType]}):"
-              str += "</td><td><strong>#{@y}</strong></td></tr>"
+              str += "</td><td><strong>#{@y} \
+              #{window.fieldUnit(data.fields[globals.configs.fieldSelection[@x]], false)}</strong></td></tr>"
               str += "</table>"
             useHTML: true
           yAxis:

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -63,7 +63,7 @@ $ ->
               str += "<tr><td>#{data.fields[globals.configs.fieldSelection[@x]].fieldName} "
               str += "(#{self.analysisTypeNames[self.configs.analysisType]}):"
               str += "</td><td><strong>#{@y} \
-              #{window.fieldUnit(data.fields[globals.configs.fieldSelection[@x]], false)}</strong></td></tr>"
+              #{fieldUnit(data.fields[globals.configs.fieldSelection[@x]], false)}</strong></td></tr>"
               str += "</table>"
             useHTML: true
           yAxis:

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -62,7 +62,8 @@ $ ->
           tooltip:
             formatter: ->
               str  = "<table>"
-              str += "<tr><td>#{fieldTitle data.fields[tooltipXAxis]}:</td><td>#{@x}<td></tr>"
+              str += "<tr><td>#{data.fields[tooltipXAxis].fieldName}:</td><td>#{@x} \
+              #{window.fieldUnit(data.fields[tooltipXAxis], false)}<td></tr>"
               str += "<tr><td># Occurrences:</td><td>#{@total}<td></tr>"
               if @y isnt 0
                 str += "<tr><td><div style='color:#{@series.color};'> #{@series.name}:</div></td>"

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -63,7 +63,7 @@ $ ->
             formatter: ->
               str  = "<table>"
               str += "<tr><td>#{data.fields[tooltipXAxis].fieldName}:</td><td>#{@x} \
-              #{window.fieldUnit(data.fields[tooltipXAxis], false)}<td></tr>"
+              #{fieldUnit(data.fields[tooltipXAxis], false)}<td></tr>"
               str += "<tr><td># Occurrences:</td><td>#{@total}<td></tr>"
               if @y isnt 0
                 str += "<tr><td><div style='color:#{@series.color};'> #{@series.name}:</div></td>"

--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -203,7 +203,6 @@ $ ->
                         </div> </br>"
 
             label += "<table>"
-
             for field, fieldIndex in data.fields when dataPoint[fieldIndex] isnt null
               dat = if (Number field.typeID) is data.types.TIME
                 (globals.dateFormatter dataPoint[fieldIndex])
@@ -211,7 +210,12 @@ $ ->
                 dataPoint[fieldIndex]
 
               label += "<tr><td>#{field.fieldName}</td>"
-              label += "<td><strong>#{dat}</strong></td></tr>"
+              label += "<td><strong>#{dat}</strong></td>"
+              unit = window.fieldUnit(field, false)
+              if unit isnt undefined and fieldIndex > 2
+                label += "<td>#{window.fieldUnit(field, false)}</td></tr>"
+              else
+                label += "</tr>"
 
             label += "</table></div>"
 

--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -211,9 +211,9 @@ $ ->
 
               label += "<tr><td>#{field.fieldName}</td>"
               label += "<td><strong>#{dat}</strong></td>"
-              unit = window.fieldUnit(field, false)
-              if unit isnt undefined and fieldIndex > 2
-                label += "<td>#{window.fieldUnit(field, false)}</td></tr>"
+              unit = fieldUnit(field, false)
+              if unit? and fieldIndex > 2
+                label += "<td>#{unit}</td></tr>"
               else
                 label += "</tr>"
 

--- a/app/assets/javascripts/visualizations/highvis/pie.coffee
+++ b/app/assets/javascripts/visualizations/highvis/pie.coffee
@@ -86,7 +86,7 @@ $ ->
               str += "<tr><td>#{data.fields[self.configs.displayField].fieldName}
                  (#{self.analysisTypeNames[self.configs.analysisType]}): "
               str += "</td><td><strong>#{@y} \
-              #{window.fieldUnit(data.fields[self.configs.displayField], false)}</strong></td></tr>"
+              #{fieldUnit(data.fields[self.configs.displayField], false)}</strong></td></tr>"
               str += "</table>"
             useHTML: true
           plotOptions:

--- a/app/assets/javascripts/visualizations/highvis/pie.coffee
+++ b/app/assets/javascripts/visualizations/highvis/pie.coffee
@@ -85,7 +85,8 @@ $ ->
               str += "<table>"
               str += "<tr><td>#{data.fields[self.configs.displayField].fieldName}
                  (#{self.analysisTypeNames[self.configs.analysisType]}): "
-              str += "</td><td><strong>#{@y}</strong></td></tr>"
+              str += "</td><td><strong>#{@y} \
+              #{window.fieldUnit(data.fields[self.configs.displayField], false)}</strong></td></tr>"
               str += "</table>"
             useHTML: true
           plotOptions:

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -150,7 +150,7 @@ $ ->
                   str += "</strong></td></tr>"
                   index = data.fields.map((y) -> y.fieldName).indexOf(@series.name.field)
                   str += "<tr><td>#{@series.name.field}:</td><td><strong>#{@y} \
-                  #{window.fieldUnit(data.fields[index], false)}</strong></td></tr>"
+                  #{fieldUnit(data.fields[index], false)}</strong></td></tr>"
                   str += "</table>"
             useHTML: true
             hideDelay: 0

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -148,7 +148,9 @@ $ ->
                   str += "<table>"
                   str += "<tr><td>#{@series.xAxis.options.title.text}:</td><td><strong>#{@x}"
                   str += "</strong></td></tr>"
-                  str += "<tr><td>#{@series.name.field}:</td><td><strong>#{@y}</strong></td></tr>"
+                  index = data.fields.map((y) -> y.fieldName).indexOf(@series.name.field)
+                  str += "<tr><td>#{@series.name.field}:</td><td><strong>#{@y} \
+                  #{window.fieldUnit(data.fields[index], false)}</strong></td></tr>"
                   str += "</table>"
             useHTML: true
             hideDelay: 0

--- a/app/assets/javascripts/visualizations/highvis/timeline.coffee
+++ b/app/assets/javascripts/visualizations/highvis/timeline.coffee
@@ -85,7 +85,7 @@ $ ->
                   str += "#{globals.dateFormatter @x}</strong></td></tr>"
                   index = data.fields.map((y) -> y.fieldName).indexOf(@series.name.field)
                   str += "<tr><td>#{@series.name.field}:</td><td><strong>#{@y} \
-                  #{window.fieldUnit(data.fields[index], false)}</strong></td></tr>"
+                  #{fieldUnit(data.fields[index], false)}</strong></td></tr>"
                   str += "</table>"
             useHTML: true
 

--- a/app/assets/javascripts/visualizations/highvis/timeline.coffee
+++ b/app/assets/javascripts/visualizations/highvis/timeline.coffee
@@ -83,7 +83,9 @@ $ ->
                   str += "<table>"
                   str += "<tr><td>#{@series.xAxis.options.title.text}:</td><td><strong> "
                   str += "#{globals.dateFormatter @x}</strong></td></tr>"
-                  str += "<tr><td>#{@series.name.field}:</td><td><strong>#{@y}</strong></td></tr>"
+                  index = data.fields.map((y) -> y.fieldName).indexOf(@series.name.field)
+                  str += "<tr><td>#{@series.name.field}:</td><td><strong>#{@y} \
+                  #{window.fieldUnit(data.fields[index], false)}</strong></td></tr>"
                   str += "</table>"
             useHTML: true
 

--- a/app/assets/javascripts/visualizations/highvis/visUtils.coffee
+++ b/app/assets/javascripts/visualizations/highvis/visUtils.coffee
@@ -48,10 +48,7 @@ $ ->
     ###
     window.fieldUnit = (field, parens = true) ->
       if field.unitName isnt null
-        if parens is true
-          "(#{field.unitName})"
-        else
-          "#{field.unitName}"
+        if parens is true then "(#{field.unitName})" else "#{field.unitName}"
 
     ###
     Removes 'item' from the array 'arr'

--- a/app/assets/javascripts/visualizations/highvis/visUtils.coffee
+++ b/app/assets/javascripts/visualizations/highvis/visUtils.coffee
@@ -34,11 +34,24 @@ $ ->
     ###
     Makes a title with apropriate units for a field
     ###
-    window.fieldTitle = (field) ->
+    window.fieldTitle = (field, parens = true) ->
       if field.unitName isnt "" and field.unitName isnt null
-        "#{field.fieldName} (#{field.unitName})"
+        if parens is true
+          "#{field.fieldName} (#{field.unitName})"
+        else
+          "#{field.fieldName} #{field.unitName}"
       else
         field.fieldName
+
+    ###
+    Returns the units for a field
+    ###
+    window.fieldUnit = (field, parens = true) ->
+      if field.unitName isnt null
+        if parens is true
+          "(#{field.unitName})"
+        else
+          "#{field.unitName}"
 
     ###
     Removes 'item' from the array 'arr'


### PR DESCRIPTION
Addresses issue #2046 .  Units (when they exist) are now displayed next to every measurement on every visualization tooltip.  @jaypoulz sorry for adding more html strings to the js!  Oops! :stuck_out_tongue: :smile: 