### PR TITLE
Fixed some bad test names

### DIFF
--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -121,7 +121,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_not_nil flash[:error]
   end
 
-  test "user can't delete themselves" do
+  test 'user cannot delete themselves' do
     assert_difference('User.count', 0) do
       delete :destroy, { id: @user },  user_id: @user
     end

--- a/test/helpers/data_sets_helper_test.rb
+++ b/test/helpers/data_sets_helper_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class DataSetsHelperTest < ActionView::TestCase
   include DataSetsHelper
 
-  test 'slickgrid data formatting - merge lat and lon' do
+  test 'slickgrid data formatting merge lat and lon' do
     project = Project.find_by_name 'slickgrid_project'
     dataset = DataSet.find_by_name 'Slickgrid Data set 1'
     cols, data = format_slickgrid_merge project.fields, dataset.data
@@ -25,7 +25,7 @@ class DataSetsHelperTest < ActionView::TestCase
     assert_similar_arrays data, resdata
   end
 
-  test 'slickgrid data formatting - skip lat, lon merge' do
+  test 'slickgrid data formatting skip lat lon merge' do
     project = Project.find_by_name 'slickgrid_project_no_latlon'
     dataset = DataSet.find_by_name 'Slickgrid Data set 2'
     cols, data = format_slickgrid_merge project.fields, dataset.data

--- a/test/integration/api_v1_test.rb
+++ b/test/integration/api_v1_test.rb
@@ -247,7 +247,7 @@ class ApiV1Test < ActionDispatch::IntegrationTest
     assert keys_match(response, @data_keys_extended), 'Keys are missing'
   end
 
-  test 'test second fields data is not trucated if longer than first fields' do
+  test 'field data not truncated if longer than first field' do
     pid = @dessert_project.id
     post "/api/v1/projects/#{pid}/jsonDataUpload",
 

--- a/test/integration/rename_viz_test.rb
+++ b/test/integration/rename_viz_test.rb
@@ -12,7 +12,7 @@ class RenameVizTest < ActionDispatch::IntegrationTest
     finish
   end
 
-  test 'create, modify, and delete a viz' do
+  test 'create modify and delete a viz' do
     login('kcarcia@cs.uml.edu', '12345')
 
     click_on 'Projects'


### PR DESCRIPTION
Some of the test names needed adjustments.
- removed commas/apostrophes/dashes
- test names < 70 chars
- test names belong in single quotes
- misspellings fixed

Addresses no issue, just a quick formatting change.