### PR TITLE
Fields should be copied when cloning a project.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -209,7 +209,7 @@ class Project < ActiveRecord::Base
     end
 
     new_project.save
-    
+
     # Clone fields
     field_map = {}
     fields.each do |f|

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -208,6 +208,8 @@ class Project < ActiveRecord::Base
       new_project.title = params[:project_name]
     end
 
+    new_project.save
+    
     # Clone fields
     field_map = {}
     fields.each do |f|

--- a/test/integration/clone_project_test.rb
+++ b/test/integration/clone_project_test.rb
@@ -68,6 +68,8 @@ class CloneProjectTest < ActionDispatch::IntegrationTest
     assert page.has_content?('test.pdf'), 'File should be in list'
     assert page.has_content?('I Like Clones'), 'Data set should be in list'
 
+    assert page.has_no_content?('Setup Manually'), 'Fields were not created'
+    
     page.find('.dataset').click_on 'Delete'
     page.driver.browser.accept_js_confirms
 

--- a/test/integration/clone_project_test.rb
+++ b/test/integration/clone_project_test.rb
@@ -69,7 +69,7 @@ class CloneProjectTest < ActionDispatch::IntegrationTest
     assert page.has_content?('I Like Clones'), 'Data set should be in list'
 
     assert page.has_no_content?('Setup Manually'), 'Fields were not created'
-    
+
     page.find('.dataset').click_on 'Delete'
     page.driver.browser.accept_js_confirms
 


### PR DESCRIPTION
1) Quick fix, @stowellm accidentally broke this on January 14th while trying to fix another bug. 
```ruby 
new_project.id
```
is null until it exists. Cloning in general is a bit wonky and needs a rewrite at some point, but it is not high priority. 

2) Added a test to make sure this doesn't happen again.
#2071  