### PR TITLE
remove spaces from version number on api page

### DIFF
--- a/app/views/home/api_v1.html.erb
+++ b/app/views/home/api_v1.html.erb
@@ -3,7 +3,7 @@
     <h1>API V1 Documentation</h1>
   </div>
   <div class="col-md-1">
-    <img alt="[iSENSE]" src="https://travis-ci.org/isenseDev/rSENSE.svg?branch=<%= @version %>"/>
+    <img alt="[iSENSE]" src="https://travis-ci.org/isenseDev/rSENSE.svg?branch=<%= @version.gsub(/\s+/, "") %>"/>
   </div>
 </div>
 <p>Client-side APIs available on <a href="https://github.com/isenseDev/iSENSE-API">Github</a> </p>


### PR DESCRIPTION
This removes any spaces from the version number. The version on travis is "Development Version" which causes it to fail HTML validation because it has a space.