### PR TITLE
Logo is no longer shortened on resize

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,8 +32,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand hidden-xs hidden-sm" href="/"><%= image_tag("isense-logo.png", height: "35") %></a>
-          <a class="navbar-brand visible-xs visible-sm" href="/"><%= image_tag("isense-logo-small.png", height: "35") %></a>
+          <a class="navbar-brand" href="/"><%= image_tag("isense-logo.png", height: "35") %></a>
         </div>
 
         <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
"iSENSE" logo no longer becomes "iS" when the browser is resized. 