### PR TITLE
Fixes field restrictions

### DIFF
--- a/app/controllers/fields_controller.rb
+++ b/app/controllers/fields_controller.rb
@@ -19,16 +19,24 @@ class FieldsController < ApplicationController
   # POST /fields
   # POST /fields.json
   def create
-    begin
-      Field.verify_params(params[:field])
-    rescue Exception => e
+    # begin
+    #   Field.verify_params(params[:field])
+    # rescue Exception => e
+    #   respond_to do |format|
+    #     format.json { render json: { msg: e }, status: :unprocessable_entity }
+    #   end
+    #   return
+    # end
+
+    @field = Field.new(field_params)
+    unless @field.valid?
       respond_to do |format|
-        format.json { render json: { msg: e }, status: :unprocessable_entity }
+        errs = @field.errors.full_messages.join ', '
+        format.json { render json: { msg: errs }, status: :unprocessable_entity }
       end
       return
     end
 
-    @field = Field.new(field_params)
     @project = Project.find(params[:field][:project_id])
 
     unless params[:field].key?(:name)

--- a/app/controllers/fields_controller.rb
+++ b/app/controllers/fields_controller.rb
@@ -19,15 +19,6 @@ class FieldsController < ApplicationController
   # POST /fields
   # POST /fields.json
   def create
-    # begin
-    #   Field.verify_params(params[:field])
-    # rescue Exception => e
-    #   respond_to do |format|
-    #     format.json { render json: { msg: e }, status: :unprocessable_entity }
-    #   end
-    #   return
-    # end
-
     @field = Field.new(field_params)
     unless @field.valid?
       respond_to do |format|

--- a/app/helpers/data_sets_helper.rb
+++ b/app/helpers/data_sets_helper.rb
@@ -16,14 +16,13 @@ module DataSetsHelper
 
   def format_slickgrid_merge(cols, data)
     cols_merge = cols.map do |x|
-      restrictions = x.restrictions.nil? ? '""' : x.restrictions
       units = x.unit.nil? ? '' : x.unit
 
       {
         field_type: x.field_type,
         id: "#{x.id}",
         name: x.name,
-        restrictions: restrictions,
+        restrictions: x.restrictions,
         units: units
       }
     end
@@ -42,7 +41,7 @@ module DataSetsHelper
         field_type: 4,
         id: "#{lat[:id]}-#{lon[:id]}",
         name: "#{lat[:name]}, #{lon[:name]}",
-        restrictions: '""',
+        restrictions: [],
         units: ''
       }
 

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -82,9 +82,9 @@ class Field < ActiveRecord::Base
   end
 
   def validate_restrictions
-    if restrictions.is_a? Array
+    if not restrictions.is_a? Array
       errors[:base] << 'Field restrictions are not in a list format'
-    elsif restrictions.reduce(true) { |a, e| a and e.is_a? String }
+    elsif not restrictions.reduce(true) { |a, e| a and e.is_a? String }
       errors[:base] << 'Not all field restrictions are strings'
     end
   end

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -1,13 +1,14 @@
 include ApplicationHelper
 class Field < ActiveRecord::Base
+  after_initialize :default_values
+  before_validation :trim_restrictions
   validates_presence_of :project_id, :field_type, :name
   validates_uniqueness_of :name, scope: :project_id, case_sensitive: false
-  validate :validate_restrictions
+  validate :validate_values
+
   belongs_to :project
   serialize :restrictions, JSON
   alias_attribute :owner, :project
-
-  before_validation :trim_restrictions
 
   default_scope { order('field_type ASC, created_at ASC') }
 
@@ -28,6 +29,10 @@ class Field < ActiveRecord::Base
   end
 
   def self.get_next_name(project, field_type)
+    if project.nil? or field_type.nil?
+      return
+    end
+
     highest = 0
     base = get_field_name(field_type)
     project.fields.where('field_type = ?', field_type).each do |f|
@@ -51,23 +56,9 @@ class Field < ActiveRecord::Base
     name
   end
 
-  def self.verify_params(params)
-    if !params.key? 'field_type'
-      fail 'No field type given'
-    else
-      unless ['1', '2', '3', '4', '5'].include?(params['field_type'].to_s)
-        fail 'Bad field type given'
-      end
-    end
-
-    if !params.key? 'project_id'
-      fail 'No project id given'
-    else
-      @project = Project.find_by_id(params['project_id']) || nil
-      if @project.nil?
-        fail 'Project not found'
-      end
-    end
+  def default_values
+    self.restrictions ||= []
+    self.name ||= Field.get_next_name project, field_type
   end
 
   def trim_restrictions
@@ -81,11 +72,23 @@ class Field < ActiveRecord::Base
     end
   end
 
-  def validate_restrictions
-    if not restrictions.is_a? Array
-      errors[:base] << 'Field restrictions are not in a list format'
-    elsif not restrictions.reduce(true) { |a, e| a and e.is_a? String }
-      errors[:base] << 'Not all field restrictions are strings'
+  def validate_values
+    # verify that restrictions is an array of strings
+    if !restrictions.is_a? Array
+      errors.add :restrictions, 'must be in an array'
+    elsif !restrictions.reduce(true) { |a, e| a and e.is_a? String }
+      errors.add :restrictions, 'must all be strings'
+    end
+
+    if !field_type.nil? and ![1, 2, 3, 4, 5].include? field_type
+      errors.add :field_type, 'must be a number between 1 and 5'
+    end
+
+    unless project_id.nil?
+      @project = Project.find_by_id(project_id)
+      if project.nil?
+        errors.add :project, 'not found'
+      end
     end
   end
 end

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -68,7 +68,7 @@ class Field < ActiveRecord::Base
     end
 
     if restrictions.is_a? Array
-      restrictions.map! { |x| x.strip }
+      restrictions.map! { |x| x.to_s.strip }
     end
   end
 
@@ -76,8 +76,8 @@ class Field < ActiveRecord::Base
     # verify that restrictions is an array of strings
     if !restrictions.is_a? Array
       errors.add :restrictions, 'must be in an array'
-    elsif !restrictions.reduce(true) { |a, e| a and e.is_a? String }
-      errors.add :restrictions, 'must all be strings'
+    elsif !restrictions.reduce(true) { |a, e| a and (e.is_a? String or e.is_a? Number) }
+      errors.add :restrictions, 'must all be parsable as strings'
     end
 
     if !field_type.nil? and ![1, 2, 3, 4, 5].include? field_type

--- a/db/migrate/20150511165600_fix_bad_restrictions.rb
+++ b/db/migrate/20150511165600_fix_bad_restrictions.rb
@@ -1,0 +1,9 @@
+class FixBadRestrictions < ActiveRecord::Migration
+  def up
+    Field.find_each do |field|
+      if field.restrictions.nil? or field.restrictions == ''
+        field.restrictions = []
+      end
+    end
+  end
+end

--- a/db/migrate/20150511165600_fix_bad_restrictions.rb
+++ b/db/migrate/20150511165600_fix_bad_restrictions.rb
@@ -1,9 +1,14 @@
 class FixBadRestrictions < ActiveRecord::Migration
   def up
+    change_column :fields, :restrictions, :text, default: '[]'
     Field.find_each do |field|
       if field.restrictions.nil? or field.restrictions == ''
         field.restrictions = []
       end
     end
+  end
+
+  def down
+    change_column :fields, :restrictions, :text, default: nil
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150403162309) do
+ActiveRecord::Schema.define(version: 20150313212337) do
 
   create_table "contrib_keys", force: true do |t|
     t.string   "name",       null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150313212337) do
+ActiveRecord::Schema.define(version: 20150511165600) do
 
   create_table "contrib_keys", force: true do |t|
     t.string   "name",       null: false
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 20150313212337) do
     t.integer  "project_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "restrictions"
+    t.text     "restrictions",             default: "[]"
   end
 
   create_table "likes", force: true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150511165600) do
+ActiveRecord::Schema.define(version: 20150403162309) do
 
   create_table "contrib_keys", force: true do |t|
     t.string   "name",       null: false
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 20150511165600) do
     t.integer  "project_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "restrictions",             default: "[]"
+    t.text     "restrictions"
   end
 
   create_table "likes", force: true do |t|

--- a/lib/file_uploader.rb
+++ b/lib/file_uploader.rb
@@ -284,7 +284,7 @@ class FileUploader
           return { status: false, msg: 'Longiude contains invalid data' }
         when 'Time'
         when 'Text'
-          unless field.restrictions.nil?
+          unless field.restrictions.length == 0
             unless field.restrictions.map { |r| r.downcase.gsub(/\s+/, '') }.include? dp.downcase.gsub(/\s+/, '')
               data[key][index] = ''
             end

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -89,6 +89,10 @@ slickgrid_oops:
   title: slickgrid_oops
   user: nixon
 
+empty_project:
+  title: empty_project
+  user: kate
+
 description_test:
   title: Goat
   user: kate

--- a/test/helpers/data_sets_helper_test.rb
+++ b/test/helpers/data_sets_helper_test.rb
@@ -9,11 +9,11 @@ class DataSetsHelperTest < ActionView::TestCase
     cols, data = format_slickgrid_merge project.fields, dataset.data
 
     rescols = [
-      { field_type: 3, id: '100', name: 'text_field', restrictions: '""', units: '' },
+      { field_type: 3, id: '100', name: 'text_field', restrictions: [], units: '' },
       { field_type: 3, id: '101', name: 'restrictions_field', restrictions: ['A', 'B', 'C'], units: '' },
-      { field_type: 2, id: '102', name: 'number_field', restrictions: '""', units: '' },
-      { field_type: 1, id: '103', name: 'timestamp_field', restrictions: '""', units: '' },
-      { field_type: 4, id: '104-105', name: 'latitude_field, longitude_field', restrictions: '""', units: '' }
+      { field_type: 2, id: '102', name: 'number_field', restrictions: [], units: '' },
+      { field_type: 1, id: '103', name: 'timestamp_field', restrictions: [], units: '' },
+      { field_type: 4, id: '104-105', name: 'latitude_field, longitude_field', restrictions: [], units: '' }
     ]
     assert_similar_arrays cols, rescols
 
@@ -30,7 +30,7 @@ class DataSetsHelperTest < ActionView::TestCase
     dataset = DataSet.find_by_name 'Slickgrid Data set 2'
     cols, data = format_slickgrid_merge project.fields, dataset.data
 
-    rescols = [{ field_type: 3, id: '106', name: 'something', restrictions: '""', units: '' }]
+    rescols = [{ field_type: 3, id: '106', name: 'something', restrictions: [], units: '' }]
     assert_similar_arrays cols, rescols
 
     resdata = [{ '106' => 'A' }, { '106' => 'B' }, { '106' => 'C' }]
@@ -66,11 +66,11 @@ class DataSetsHelperTest < ActionView::TestCase
     cols, data = format_slickgrid_editors cols, data
 
     rescols = [
-      { id: '"slickgrid-100"', name: '"text_field"', field: '"100"', editor: 'TextEditor', restrictions: '""', sortable: 'false' },
+      { id: '"slickgrid-100"', name: '"text_field"', field: '"100"', editor: 'TextEditor', restrictions: '[]', sortable: 'false' },
       { id: '"slickgrid-101"', name: '"restrictions_field"', field: '"101"', editor: 'TextEditor', restrictions: '["A", "B", "C"]', sortable: 'false' },
-      { id: '"slickgrid-102"', name: '"number_field"', field: '"102"', editor: 'NumberEditor', restrictions: '""', sortable: 'false' },
-      { id: '"slickgrid-103"', name: '"timestamp_field"', field: '"103"', editor: 'TimestampEditor', restrictions: '""', sortable: 'false' },
-      { id: '"slickgrid-104-105"', name: '"latitude_field, longitude_field"', field: '"104-105"', editor: 'LocationEditor', restrictions: '""', sortable: 'false' }
+      { id: '"slickgrid-102"', name: '"number_field"', field: '"102"', editor: 'NumberEditor', restrictions: '[]', sortable: 'false' },
+      { id: '"slickgrid-103"', name: '"timestamp_field"', field: '"103"', editor: 'TimestampEditor', restrictions: '[]', sortable: 'false' },
+      { id: '"slickgrid-104-105"', name: '"latitude_field, longitude_field"', field: '"104-105"', editor: 'LocationEditor', restrictions: '[]', sortable: 'false' }
     ]
     assert_similar_arrays cols, rescols
 
@@ -88,7 +88,7 @@ class DataSetsHelperTest < ActionView::TestCase
     cols, data = format_slickgrid_editors cols, data
 
     rescols = [
-      { id: '"slickgrid-107"', name: '"oops"', field: '"107"', editor: 'Slick.Editors.Text', restrictions: '""', sortable: 'false' }
+      { id: '"slickgrid-107"', name: '"oops"', field: '"107"', editor: 'Slick.Editors.Text', restrictions: '[]', sortable: 'false' }
     ]
     assert_similar_arrays cols, rescols
 
@@ -116,11 +116,11 @@ class DataSetsHelperTest < ActionView::TestCase
     end
 
     jrescols = [
-      { 'id' => 'slickgrid-100', 'name' => 'text_field', 'field' => '100', 'editor' => 'TextEditor', 'restrictions' => '', 'sortable' => false },
+      { 'id' => 'slickgrid-100', 'name' => 'text_field', 'field' => '100', 'editor' => 'TextEditor', 'restrictions' => [], 'sortable' => false },
       { 'id' => 'slickgrid-101', 'name' => 'restrictions_field', 'field' => '101', 'editor' => 'TextEditor', 'restrictions' => ['A', 'B', 'C'], 'sortable' => false },
-      { 'id' => 'slickgrid-102', 'name' => 'number_field', 'field' => '102', 'editor' => 'NumberEditor', 'restrictions' => '', 'sortable' => false },
-      { 'id' => 'slickgrid-103', 'name' => 'timestamp_field', 'field' => '103', 'editor' => 'TimestampEditor', 'restrictions' => '', 'sortable' => false },
-      { 'id' => 'slickgrid-104-105', 'name' => 'latitude_field, longitude_field', 'field' => '104-105', 'editor' => 'LocationEditor', 'restrictions' => '', 'sortable' => false }
+      { 'id' => 'slickgrid-102', 'name' => 'number_field', 'field' => '102', 'editor' => 'NumberEditor', 'restrictions' => [], 'sortable' => false },
+      { 'id' => 'slickgrid-103', 'name' => 'timestamp_field', 'field' => '103', 'editor' => 'TimestampEditor', 'restrictions' => [], 'sortable' => false },
+      { 'id' => 'slickgrid-104-105', 'name' => 'latitude_field, longitude_field', 'field' => '104-105', 'editor' => 'LocationEditor', 'restrictions' => [], 'sortable' => false }
     ]
     assert_similar_arrays jcols, jrescols
 
@@ -147,11 +147,11 @@ class DataSetsHelperTest < ActionView::TestCase
     end
 
     jrescols = [
-      { 'id' => 'slickgrid-100', 'name' => 'text_field<br>', 'field' => '100', 'editor' => 'TextEditor', 'restrictions' => '', 'sortable' => false },
+      { 'id' => 'slickgrid-100', 'name' => 'text_field<br>', 'field' => '100', 'editor' => 'TextEditor', 'restrictions' => [], 'sortable' => false },
       { 'id' => 'slickgrid-101', 'name' => 'restrictions_field<br>', 'field' => '101', 'editor' => 'TextEditor', 'restrictions' => ['A', 'B', 'C'], 'sortable' => false },
-      { 'id' => 'slickgrid-102', 'name' => 'number_field<br>', 'field' => '102', 'editor' => 'NumberEditor', 'restrictions' => '', 'sortable' => false },
-      { 'id' => 'slickgrid-103', 'name' => 'timestamp_field<br>', 'field' => '103', 'editor' => 'TimestampEditor', 'restrictions' => '', 'sortable' => false },
-      { 'id' => 'slickgrid-104-105', 'name' => 'latitude_field, longitude_field<br>', 'field' => '104-105', 'editor' => 'LocationEditor', 'restrictions' => '', 'sortable' => false }
+      { 'id' => 'slickgrid-102', 'name' => 'number_field<br>', 'field' => '102', 'editor' => 'NumberEditor', 'restrictions' => [], 'sortable' => false },
+      { 'id' => 'slickgrid-103', 'name' => 'timestamp_field<br>', 'field' => '103', 'editor' => 'TimestampEditor', 'restrictions' => [], 'sortable' => false },
+      { 'id' => 'slickgrid-104-105', 'name' => 'latitude_field, longitude_field<br>', 'field' => '104-105', 'editor' => 'LocationEditor', 'restrictions' => [], 'sortable' => false }
     ]
     assert_similar_arrays jcols, jrescols
 


### PR DESCRIPTION
Addresses #2024.

Field restrictions are now constrained to being just an array of restrictions.  Previously, a lack of restrictions could be represented as an empty string, an empty array, or nil.

This was done by having the fields model actually validate restrictions.  I also had to fix some tests, and I removed some code from FileUploader that would reject any text entered in a field that had no restrictions because the entered text wasn't in the empty array of restrictions.

I also cleaned up how validation was done.  I am also no longer returning just one error if the user fails create a field, but instead all of them.  This useful in regards to the API and stuff.