### PR TITLE
Standard deviation on bar chart again

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -36,6 +36,7 @@
 //
 //  -- Visualization stuff follows --
 //= require highcharts/highcharts
+//= require highcharts/highcharts-more
 //= require highcharts/modules/exporting
 //= require jquery.jqGrid.src.js
 //= require grid.locale-en.js

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -117,8 +117,13 @@ $ ->
               else
                 mean = groupedData[fid][gid]
                 innerStd = barData.map((x) -> (x - mean) ** 2).reduce((x, y) -> x + y)
-                stdDev = Math.sqrt (1 / (barData.length - 1)) * innerStd
-                [mean - stdDev, mean + stdDev]
+                stdDev = Math.sqrt((1 / (barData.length - 1)) * innerStd)
+                if globals.configs.logY != true
+                  [mean - stdDev, mean + stdDev]
+                else if mean > 0
+                  [mean, mean + stdDev]
+                else
+                  []
 
             @chart.addSeries errors
 
@@ -129,6 +134,7 @@ $ ->
 
       drawControls: ->
         super()
+
         @drawGroupControls(data.textFields)
         @drawYAxisControls(globals.configs.fieldSelection,
           data.normalFields.slice(1), false)

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -118,7 +118,7 @@ $ ->
                 mean = groupedData[fid][gid]
                 innerStd = barData.map((x) -> (x - mean) ** 2).reduce((x, y) -> x + y)
                 stdDev = Math.sqrt((1 / (barData.length - 1)) * innerStd)
-                if globals.configs.logY != true
+                if !globals.configs.logY
                   [mean - stdDev, mean + stdDev]
                 else if mean > 0
                   [mean, mean + stdDev]

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -103,6 +103,25 @@ $ ->
             [fieldTitle(data.fields[fid]), groupedData[fid][gid]]
 
           @chart.addSeries options, false
+
+          # Draw error bars if that analysis type is selected
+          if @configs.analysisType == @ANALYSISTYPE_MEAN_ERROR
+            errors =
+              type: 'errorbar'
+              name: "Error for #{data.groups[gid]}" or data.noField()
+
+            errors.data = for fid in data.normalFields when fid in fieldSelection
+              barData = data.selector fid, gid
+              if barData.length == 1
+                []
+              else
+                mean = groupedData[fid][gid]
+                innerStd = barData.map((x) -> (x - mean) ** 2).reduce((x, y) -> x + y)
+                stdDev = Math.sqrt (1 / (barData.length - 1)) * innerStd
+                [mean - stdDev, mean + stdDev]
+
+            @chart.addSeries errors
+
         @chart.redraw()
 
       buildLegendSeries: ->

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -36,17 +36,18 @@ $ ->
       constructor: (@canvas) ->
         @configs ?= {}
 
-      ANALYSISTYPE_TOTAL:     0
-      ANALYSISTYPE_MAX:       1
-      ANALYSISTYPE_MIN:       2
-      ANALYSISTYPE_MEAN:      3
-      ANALYSISTYPE_MEDIAN:    4
-      ANALYSISTYPE_COUNT:     5
+      ANALYSISTYPE_TOTAL:      0
+      ANALYSISTYPE_MAX:        1
+      ANALYSISTYPE_MIN:        2
+      ANALYSISTYPE_MEAN:       3
+      ANALYSISTYPE_MEAN_ERROR: 4
+      ANALYSISTYPE_MEDIAN:     5
+      ANALYSISTYPE_COUNT:      6
 
-      SORT_DEFAULT:          -1
+      SORT_DEFAULT:           -1
 
-      analysisTypeNames: ["Total", "Maximum", "Mininum", "Mean (Average)",
-        "Median", "Row Count"]
+      analysisTypeNames: ['Total', 'Maximum', 'Mininum', 'Mean (Average)',
+        'Mean with Error', 'Median', 'Row Count']
 
       ###
       Start sequence used by runtime
@@ -104,14 +105,20 @@ $ ->
       ###
       getGroupedData: (field) ->
         gData = {}
-        for name, i in data.groups when i in data.groupSelection
+
+        analysisMethod =
           switch @configs.analysisType
-            when @ANALYSISTYPE_TOTAL  then gData[i] = (data.getTotal  field, i)
-            when @ANALYSISTYPE_MAX    then gData[i] = (data.getMax    field, i)
-            when @ANALYSISTYPE_MIN    then gData[i] = (data.getMin    field, i)
-            when @ANALYSISTYPE_MEAN   then gData[i] = (data.getMean   field, i)
-            when @ANALYSISTYPE_MEDIAN then gData[i] = (data.getMedian field, i)
-            when @ANALYSISTYPE_COUNT  then gData[i] = (data.getCount  field, i)
+            when @ANALYSISTYPE_TOTAL      then data.getTotal
+            when @ANALYSISTYPE_MAX        then data.getMax
+            when @ANALYSISTYPE_MIN        then data.getMin
+            when @ANALYSISTYPE_MEAN       then data.getMean
+            when @ANALYSISTYPE_MEAN_ERROR then data.getMean
+            when @ANALYSISTYPE_MEDIAN     then data.getMedian
+            when @ANALYSISTYPE_COUNT      then data.getCount
+
+        for name, i in data.groups when i in data.groupSelection
+          gData[i] = analysisMethod.call data, field, i
+
         gData
 
       ###
@@ -413,7 +420,7 @@ $ ->
       Draw tool controls (Analysis Type, Log Y Axis, etc.) for Pie Chart and
       Bar Charts
       ###
-      drawToolControls: (sortBy = false, logYAxis = false) ->
+      drawToolControls: (sortBy = false, logYAxis = false, analysisTypeExcludes = []) ->
         inctx = {}
 
         # Populate sort fields
@@ -429,14 +436,27 @@ $ ->
             logId: 'sort-by-' + @SORT_DEFAULT
             value: @SORT_DEFAULT
 
+        # Set up analysis types from the list of exclusions
+        analysisTypes = [
+          @ANALYSISTYPE_TOTAL
+          @ANALYSISTYPE_MAX
+          @ANALYSISTYPE_MIN
+          @ANALYSISTYPE_MEAN
+          @ANALYSISTYPE_MEAN_ERROR
+          @ANALYSISTYPE_MEDIAN
+          @ANALYSISTYPE_COUNT
+          ]
+        analysisTypes = analysisTypes.filter (x) ->
+          x not in analysisTypeExcludes
+
         # Analysis Types
         inctx.analysisTypes =
-          for name, i in @analysisTypeNames
+          for i in analysisTypes
             value: i
             id:    'analysis-type-' + i
             logId: 'analysis-type-' + i
             name:  'analysis-type'
-            label:  name
+            label:  @analysisTypeNames[i]
 
         # Logarithmic Y Axis
         if logYAxis

--- a/app/assets/javascripts/visualizations/highvis/pie.coffee
+++ b/app/assets/javascripts/visualizations/highvis/pie.coffee
@@ -48,7 +48,8 @@ $ ->
 
         @configs.selectName = data.fields[globals.configs.groupById].fieldName
 
-        displayData = for gid, val of @getGroupedData(@configs.displayField)
+        groupedData = @getGroupedData(@configs.displayField)
+        displayData = for gid, val of groupedData
           ret =
             y: if val < 0 then 0 else val            # for calculations
             val: val                                 # for display
@@ -104,7 +105,7 @@ $ ->
         @drawYAxisControls(globals.configs.fieldSelection,
           data.normalFields.slice(1), true, 'Fields', @configs.displayField,
           @yAxisRadioHandler)
-        @drawToolControls()
+        @drawToolControls(false, false, [@ANALYSISTYPE_MEAN_ERROR])
         @drawSaveControls()
 
     if "Pie" in data.relVis

--- a/db/migrate/20150519161334_add_mean_error_bars.rb
+++ b/db/migrate/20150519161334_add_mean_error_bars.rb
@@ -8,11 +8,11 @@ class AddMeanErrorBars < ActiveRecord::Migration
 
       # Mean with Error was inserted at position 4, so everything 4 or greater
       # gets moved up by 1
-      if !y['Bar'].nil? and !y['Bar'].empty? and y['Bar']['analysisType'] >= 4
+      if !y['Bar'].nil? and !y['Bar']['analysisType'].nil? and y['Bar']['analysisType'] >= 4
         y['Bar']['analysisType'] += 1
       end
 
-      if !y['Pie'].nil? and !y['Pie'].empty? and y['Pie']['analysisType'] >= 4
+      if !y['Pie'].nil? and !y['Pie']['analysisType'].nil? and y['Pie']['analysisType'] >= 4
         y['Pie']['analysisType'] += 1
       end
 
@@ -25,11 +25,11 @@ class AddMeanErrorBars < ActiveRecord::Migration
       next if x.globals.nil?
       y = JSON.parse x.globals
 
-      if !y['Bar'].nil? and !y['Bar'].empty? and y['Bar']['analysisType'] >= 4
+      if !y['Bar'].nil? and !y['Bar']['analysisType'].nil? and y['Bar']['analysisType'] >= 4
         y['Bar']['analysisType'] += 1
       end
 
-      if !y['Pie'].nil? and !y['Pie'].empty? and y['Pie']['analysisType'] >= 4
+      if !y['Pie'].nil? and !y['Pie']['analysisType'].nil? and y['Pie']['analysisType'] >= 4
         y['Pie']['analysisType'] += 1
       end
 
@@ -48,11 +48,11 @@ class AddMeanErrorBars < ActiveRecord::Migration
       # greater than 4 get shifted down to the correct analysis type, and converts
       # all "Mean with Error" analysis types to just "Mean (average)" analysis
       # types
-      if !y['Bar'].nil? and !y['Bar'].empty? and y['Bar']['analysisType'] >= 4
+      if !y['Bar'].nil? and !y['Bar']['analysisType'].nil? and y['Bar']['analysisType'] >= 4
         y['Bar']['analysisType'] -= 1
       end
 
-      if !y['Pie'].nil? and !y['Pie'].empty? and y['Pie']['analysisType'] >= 4
+      if !y['Pie'].nil? and !y['Pie']['analysisType'].nil? and y['Pie']['analysisType'] >= 4
         y['Pie']['analysisType'] -= 1
       end
 
@@ -65,11 +65,11 @@ class AddMeanErrorBars < ActiveRecord::Migration
       next if x.globals.nil?
       y = JSON.parse x.globals
 
-      if !y['Bar'].nil? and !y['Bar'].empty? and y['Bar']['analysisType'] >= 4
+      if !y['Bar'].nil? and !y['Bar']['analysisType'].nil? and y['Bar']['analysisType'] >= 4
         y['Bar']['analysisType'] -= 1
       end
 
-      if !y['Pie'].nil? and !y['Pie'].empty? and y['Pie']['analysisType'] >= 4
+      if !y['Pie'].nil? and !y['Pie']['analysisType'].nil? and y['Pie']['analysisType'] >= 4
         y['Pie']['analysisType'] -= 1
       end
 

--- a/db/migrate/20150519161334_add_mean_error_bars.rb
+++ b/db/migrate/20150519161334_add_mean_error_bars.rb
@@ -1,0 +1,80 @@
+class AddMeanErrorBars < ActiveRecord::Migration
+  def up
+    # Fix all saved visualizations to accomondate the new analysis type
+    Visualization.find_each do |x|
+      next if x.globals.nil?
+      y = JSON.parse x.globals
+      next if y['Bar'].empty?
+
+      # Mean with Error was inserted at position 4, so everything 4 or greater
+      # gets moved up by 1
+      if !y['Bar'].nil? and !y['Bar'].empty? and y['Bar']['analysisType'] >= 4
+        y['Bar']['analysisType'] += 1
+      end
+
+      if !y['Pie'].nil? and !y['Pie'].empty? and y['Pie']['analysisType'] >= 4
+        y['Pie']['analysisType'] += 1
+      end
+
+      x.globals = JSON.dump y
+      x.save!
+    end
+
+    # Do the same as above, but for default visualizations
+    Project.find_each do |x|
+      next if x.globals.nil?
+      y = JSON.parse x.globals
+
+      if !y['Bar'].nil? and !y['Bar'].empty? and y['Bar']['analysisType'] >= 4
+        y['Bar']['analysisType'] += 1
+      end
+
+      if !y['Pie'].nil? and !y['Pie'].empty? and y['Pie']['analysisType'] >= 4
+        y['Pie']['analysisType'] += 1
+      end
+
+      x.globals = JSON.dump y
+      x.save!
+    end
+  end
+
+  def down
+    # Fix all saved visualizations to revert back to the old analysis types
+    Visualization.find_each do |x|
+      next if x.globals.nil?
+      y = JSON.parse x.globals
+
+      # Mean with Error was inserted at position 4.  This makes everything
+      # greater than 4 get shifted down to the correct analysis type, and converts
+      # all "Mean with Error" analysis types to just "Mean (average)" analysis
+      # types
+      if !y['Bar'].nil? and !y['Bar'].empty? and y['Bar']['analysisType'] >= 4
+        y['Bar']['analysisType'] -= 1
+      end
+
+      if !y['Pie'].nil? and !y['Pie'].empty? and y['Pie']['analysisType'] >= 4
+        y['Pie']['analysisType'] -= 1
+      end
+
+      x.globals = JSON.dump y
+      x.save!
+    end
+
+    # Do the same as above, but for default visualizations
+    Project.find_each do |x|
+      next if x.globals.nil?
+      y = JSON.parse x.globals
+
+      if !y['Bar'].nil? and !y['Bar'].empty? and y['Bar']['analysisType'] >= 4
+        y['Bar']['analysisType'] -= 1
+      end
+
+      if !y['Pie'].nil? and !y['Pie'].empty? and y['Pie']['analysisType'] >= 4
+        y['Pie']['analysisType'] -= 1
+      end
+
+      x.globals = JSON.dump y
+      x.save!
+    end
+  end
+end

--- a/test/fixtures/tutorials.yml
+++ b/test/fixtures/tutorials.yml
@@ -13,7 +13,7 @@ two:
   featured: false
   user: nixon
   hidden: false
-  
+
 media_test:
   content: MyText
   title: Tutorial Three

--- a/test/fixtures/visualizations.yml
+++ b/test/fixtures/visualizations.yml
@@ -1,35 +1,35 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
 
-#Don't know what to put in content, data, and global fields
+# Don't know what to put in content, data, and global fields
 
 visualization1:
   title: VisualizationTitle1
   user: kate
   project: one
-  content: MyText
+  content: "fill me in later!"
   data: '{"defaultVis":"Map", "relVis":["Map"]}'
-  globals: MyText
+  globals: '{"Bar":{"analysisType": 1}}'
 
 tasty_vis:
   title: Tasty Vis
   user: kate
   project: dessert
-  content: MyText
+  content: "fill me in later!"
   data: '{"defaultVis":"Summary", "relVis":["Summary"]}'
-  globals: MyText
+  globals: '{"Bar":{"analysisType": 1}}'
 
 needs_media:
   title: Needs Media
   user: nixon
   project: one
-  content: MyText
+  content: "fill me in later!"
   data: '{"defaultVis":"Scatter", "relVis":["Scatter"]}'
-  globals: MyText
+  globals: '{"Bar":{"analysisType": 4}}'
 
 media_test:
   title: Needs Media
   user: nixon
   project: one
-  content: MyText
+  content: "fill me in later!"
   data: '{"defaultVis":"Table", "relVis":["Table"]}'
-  globals: MyText
+  globals: '{"Bar":{"analysisType": 5}}'


### PR DESCRIPTION
Addresses #1896, #2158.

Fixes the migration to test a little more rigorously for what data is actually present in saved and default vises.  Turns out it was less consistent than I thought it was.

Also fixes standard deviation on logarithmic y-axis.  According to [this article](http://www.graphpad.com/faq/file/1487logaxes.pdf), showing standard deviation error bars on a log y axis is considered an "abuse" and makes literally no sense, so I made my fix reflect that.  Only the top part of error bars for non-negative means are shown.