### PR TITLE
Number of columns on table is now based on screen size

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/table.coffee
+++ b/app/assets/javascripts/visualizations/highvis/table.coffee
@@ -36,7 +36,8 @@ $ ->
         @TOOLBAR_HEIGHT_OFFSET = 70
 
         fieldList = (i for f, i in data.fields when i isnt data.COMBINED_FIELD)
-        @configs.tableFields ?= fieldList[0..7]
+        rows = Math.round( $(window).width() / 180 )
+        @configs.tableFields ?= fieldList[0..rows]
 
         # Set sort state to default none existed
         @configs.sortName ?= ''


### PR DESCRIPTION
Previously the number of columns that a table had by default was 8 regardless of screen size. Now it is based upon the screen's width.

Fixes #2156 