### PR TITLE
Fixing duplicate colorpickers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,7 @@ end
 
 # Jquery stuff
 gem 'better_datetimepicker', '~> 0.0.7', git: 'https://github.com/isenseDev/better-datetimepicker'
-# gem 'better_colorpicker', '~> 0.0.3', git: 'https://github.com/isenseDev/better-colorpicker'
-gem 'better_colorpicker', path: '~/Documents/ecg/better-colorpicker'
+gem 'better_colorpicker', '~> 0.1.0', git: 'https://github.com/isenseDev/better-colorpicker'
 gem 'jquery-rails'
 
 # To use ActiveModel has_secure_password

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,8 @@ end
 
 # Jquery stuff
 gem 'better_datetimepicker', '~> 0.0.7', git: 'https://github.com/isenseDev/better-datetimepicker'
-gem 'better_colorpicker', '~> 0.0.3', git: 'https://github.com/isenseDev/better-colorpicker'
+# gem 'better_colorpicker', '~> 0.0.3', git: 'https://github.com/isenseDev/better-colorpicker'
+gem 'better_colorpicker', path: '~/Documents/ecg/better-colorpicker'
 gem 'jquery-rails'
 
 # To use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,13 +21,6 @@ GIT
       ruby-progressbar (~> 1.4)
 
 GIT
-  remote: https://github.com/isenseDev/better-colorpicker
-  revision: 72f3f116a383218287fce45401088d940e2cddb2
-  specs:
-    better_colorpicker (0.0.3)
-      rails (~> 4.1.4)
-
-GIT
   remote: https://github.com/isenseDev/better-datetimepicker
   revision: 9aa5f12d3b08675c5e0cdff6374564ed98a6073f
   specs:
@@ -36,6 +29,12 @@ GIT
       coffee-rails-source-maps
       rails (~> 4)
       sass
+
+PATH
+  remote: ~/Documents/ecg/better-colorpicker
+  specs:
+    better_colorpicker (0.0.3)
+      rails (~> 4.1.4)
 
 GEM
   remote: https://rubygems.org/
@@ -248,7 +247,7 @@ PLATFORMS
 DEPENDENCIES
   auto_html
   bcrypt-ruby
-  better_colorpicker (~> 0.0.3)!
+  better_colorpicker!
   better_datetimepicker (~> 0.0.7)!
   bootstrap-sass
   browser

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -303,11 +303,12 @@ $ ->
 
         $('.color-picker').each (_, cpicker) =>
           cid = $(cpicker).data('color-id')
-          $(cpicker).colorpicker 'create',
+          a = $(cpicker).colorpicker
             outputType: 'hex'
             onOpen: () ->
               $("#label-color-#{cid}").parent().parent().css('background-color',
                 '#EEE')
+              globals.getColor(cid)
             onClose: () ->
               $("#label-color-#{cid}").parent().parent().css('background-color',
                 '#FFF')
@@ -316,7 +317,19 @@ $ ->
               $("#label-color-#{cid}").css 'color', color
               @delayedUpdate()
               setTimeout (() => @start()), 1
-          $(cpicker).colorpicker 'setcolor', globals.getColor(cid)
+            hPosition: (w, h) =>
+              button = $(cpicker).children('img')
+              buttonX = button.offset().left
+              buttonW = button.width()
+              buttonX - w + buttonW
+            vPosition: (w, h) =>
+              button = $(cpicker).children('img')
+              buttonY = button.offset().top
+              buttonH = button.height()
+              buttonY + buttonH
+
+          $(cpicker).click ->
+            a.open()
 
         $('#group-by').val(globals.configs.groupById)
         $('#group-by').change (e) =>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150511165600) do
+ActiveRecord::Schema.define(version: 20150519161334) do
 
   create_table "contrib_keys", force: true do |t|
     t.string   "name",       null: false
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20150511165600) do
     t.integer  "news_id"
     t.string   "store_key"
     t.string   "file"
+    t.string   "md5"
   end
 
   create_table "news", force: true do |t|


### PR DESCRIPTION
Addresses #2004.

Companion pull request for https://github.com/isenseDev/better-colorpicker/pull/1.  Don't do anything with this until that is merged.

This gets rid of the old colorpicker.  It was a good first try, but it had a couple of problems.  Primarily, it would created one instance of itself in the DOM per group.  This is OK on most projects, but was still bad practice.  It also allowed more than one color picker to exist on screen at a time.

This should probably be tested locally before being merged.