### PR TITLE
Tells cloned projects that their parent is dead when you kill them

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -211,6 +211,11 @@ class ProjectsController < ApplicationController
       m.destroy
     end
 
+    Project.where('cloned_from = ?', @project.id).each do |clone|
+      clone.cloned_from = nil
+      clone.save!
+    end
+
     @project.destroy
 
     respond_to do |format|


### PR DESCRIPTION
Addresses #2180.

When you delete a project that has been cloned from, it tells all of the clones that you deleted their parent.  This prevents the website from breaking when a user tries to view a project that comes from a cloned project.  The break happens because it called `Project.find(id)` although `id` isn't in the database.

I didn't bother writing a migration because this hasn't happened on live.  The only way that this can happen is if the cloned project doesn't have data, which doesn't really make much sense to do in practice.