### PR TITLE
Purges useless AJAX and can no longer set invalid media objects as featured

### DIFF
--- a/app/assets/javascripts/shared/media_objects_view.js.coffee
+++ b/app/assets/javascripts/shared/media_objects_view.js.coffee
@@ -15,6 +15,7 @@ setupMediaObjectsView = () ->
     type_id = obj.attr("obj_id")
     type = root.attr("data-type")
     mo = if obj.prop("checked") == false then null else obj.attr("mo_id")
+    old_mo = root.find('table > tbody > tr > td input[checked]')
 
     data = {}
     data[type] = {}
@@ -26,18 +27,20 @@ setupMediaObjectsView = () ->
       dataType: "json"
       data:
         data
-      error: ->
+      error: (j, s, t) ->
+        console.log j, s, t
         root.find('.img_selector').each ->
           ($ this).prop("checked", false)
+        old_mo.prop("checked", true)
+        quickFlash(JSON.parse(j.responseText), 'error')
       success: ->
         root.find('.img_selector').each ->
           if ($ this).attr("mo_id") != mo
             ($ this).prop("checked", false)
 
-  ($ 'a.media_object_delete').click (e) ->
-    e.preventDefault()
-    delete_media_object ($ @)
+  $('.img_selector').click ->
+    img_selector_click ($ @)
 
-$ ->
+$(document).ready ->
   if $('.upload_media')?
     setupMediaObjectsView()

--- a/app/assets/javascripts/shared/media_objects_view.js.coffee
+++ b/app/assets/javascripts/shared/media_objects_view.js.coffee
@@ -34,32 +34,6 @@ setupMediaObjectsView = () ->
           if ($ this).attr("mo_id") != mo
             ($ this).prop("checked", false)
 
-  ($ '.img_selector').click ->
-    img_selector_click ($ @)
-
-  # Delete Media Object
-  delete_media_object = (obj) ->
-    if helpers.confirm_delete obj.attr('name')
-      $.ajax
-        url: obj.attr("href")
-        type: 'DELETE'
-        dataType: "json"
-        error: (j, s, t) ->
-          errors = JSON.parse j.responseText
-          $(obj).popover
-            content: errors[0]
-            placement: "bottom"
-            trigger: "manual"
-          $(obj).popover 'show'
-        success: ->
-          recolored = false
-          row = obj.parents('tr')
-          tbody = row.parents('tbody')
-          row.delete_row ->
-            row.remove()
-            tbody.recolor_rows(recolored)
-            recolored = true
-
   ($ 'a.media_object_delete').click (e) ->
     e.preventDefault()
     delete_media_object ($ @)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -40,7 +40,7 @@ class Project < ActiveRecord::Base
   end
 
   def media_object_exists
-    if !self.featured_media_id.nil? and MediaObject.where(id: self.featured_media_id).blank?
+    if !featured_media_id.nil? and MediaObject.where(id: featured_media_id).blank?
       errors.add :base, 'That media object no longer exists.'
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,12 +5,15 @@ class Project < ActiveRecord::Base
   include ActionView::Helpers::DateHelper
   include ActionView::Helpers::SanitizeHelper
 
+  before_validation :sanitize_project
+
   validates_presence_of :title
   validates_presence_of :user_id
-
   validates :title, length: { maximum: 128 }
-  before_validation :sanitize_project
+  validate :media_object_exists
+
   before_save :summernote_media_objects
+
   has_many :fields
   has_many :data_sets, -> { order('created_at desc') }
   has_many :media_objects
@@ -34,6 +37,12 @@ class Project < ActiveRecord::Base
     end
 
     self.title = sanitize title, tags: %w()
+  end
+
+  def media_object_exists
+    if MediaObject.where(id: self.featured_media_id).blank?
+      errors.add :base, 'That media object no longer exists.'
+    end
   end
 
   def self.search(search, include_hidden = false)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -40,7 +40,7 @@ class Project < ActiveRecord::Base
   end
 
   def media_object_exists
-    if MediaObject.where(id: self.featured_media_id).blank?
+    if !self.featured_media_id.nil? and MediaObject.where(id: self.featured_media_id).blank?
       errors.add :base, 'That media object no longer exists.'
     end
   end

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -83,4 +83,14 @@ class ProjectTest < ActiveSupport::TestCase
   test 'project featured_media_id' do
     assert_nil projects(:one).featured_media_id, 'Expected project featured_media_id is not nil.'
   end
+
+  #-----------------------------------------------------------------------------
+  # Testing validation
+
+  test 'invalid media object id' do
+    old_media_id = @project.featured_media_id
+    @project.featured_media_id = -1
+    refute @project.valid?
+    @project.featured_media_id = old_media_id
+  end
 end


### PR DESCRIPTION
Addresses #1262, #2196

The AJAX can be broken down as follows:
* **shared/media_objects_view:** removed useless block of code for deleting pictures, added validation for featuring media objects
* **visualizations/highvis/savedVis:** not touching this, as it's important and recent so it's OK
* **data_sets/editTable:** needed because data needs to persist in case you did something wrong
* **users/show:** used for efficiently sorting and filtering user contributions and hiding/unhiding stuff
* **projects/show:** used for liking,  and deleting data sets and saved visualizations

So, overall, I made a change.

Also, I had to fix some stuff regarding media objects.  That was fixed, and now we actually validate featured media objects.