### PR TITLE
fix appending and editing for contribution keys through api

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,10 +130,10 @@ class ApplicationController < ActionController::Base
           (['append', 'edit'].include? params[:action]) &&
           params[:controller].include?('data_sets')
       data_set = DataSet.find_by_id(params[:id])
-      if data_set && 
+      if data_set &&
         !data_set.project.contrib_keys.find_by_key(params[:contribution_key].downcase).nil? &&
         data_set.key == data_set.project.contrib_keys.where(key: params[:contribution_key].downcase)[0].name
-         
+
         @cur_user = User.find_by_id(data_set.owner.id)
       else
         respond_to do |format|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,9 +130,10 @@ class ApplicationController < ActionController::Base
           (['append', 'edit'].include? params[:action]) &&
           params[:controller].include?('data_sets')
       data_set = DataSet.find_by_id(params[:id])
-      if data_set &&
-         data_set.key == data_set.project.contrib_keys.where(key: params[:contribution_key].downcase)[0].name &&
-         !data_set.project.contrib_keys.find_by_key(params[:contribution_key].downcase).nil?
+      if data_set && 
+        !data_set.project.contrib_keys.find_by_key(params[:contribution_key].downcase).nil? &&
+        data_set.key == data_set.project.contrib_keys.where(key: params[:contribution_key].downcase)[0].name
+         
         @cur_user = User.find_by_id(data_set.owner.id)
       else
         respond_to do |format|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -131,7 +131,7 @@ class ApplicationController < ActionController::Base
           params[:controller].include?('data_sets')
       data_set = DataSet.find_by_id(params[:id])
       if data_set &&
-         data_set.key == params[:contribution_key].downcase &&
+         data_set.key == data_set.project.contrib_keys.where(key: params[:contribution_key].downcase)[0].name &&
          !data_set.project.contrib_keys.find_by_key(params[:contribution_key].downcase).nil?
         @cur_user = User.find_by_id(data_set.owner.id)
       else

--- a/test/fixtures/data_sets.yml
+++ b/test/fixtures/data_sets.yml
@@ -15,7 +15,7 @@ thanksgiving:
   user: kate
   project: dessert
   data: "[{\"20\": 1, \"21\": 2, \"22\": 3},{\"20\": 1, \"21\": 2, \"22\": 3}]"
-  key: apple
+  key: Pies
   
 needs_media:
   title: Needs Media


### PR DESCRIPTION
#2251
It was previously comparing the label of the key that was used to create the data set and the key that the user was passing as a parameter.