### PR TITLE
Fixes the integrations

### DIFF
--- a/app/assets/javascripts/home.js.coffee
+++ b/app/assets/javascripts/home.js.coffee
@@ -3,8 +3,11 @@
 # You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
 
 $ ->
-  ($ '.mainContent').on 'click', 'div.clickableItem', (event) ->
+  $('.mainContent').on 'click', 'div.clickableItem', (event) ->
     window.location = ($ event.currentTarget).children('a').attr 'href'
-  ($ 'li.dropdown.navbtn').click () ->
-    ($ 'li.dropdown.navbtn').find('a:first').css 'color', 'white'
-    ($ 'li.dropdown.navbtn').removeAttr 'disabled'
+  $('li.dropdown.navbtn').click () ->
+    $('li.dropdown.navbtn').find('a:first').css 'color', 'white'
+    $('li.dropdown.navbtn').removeAttr 'disabled'
+  if window.env == 'test'
+    $('input[type=file]').show()
+    $('.hidden-form').show()

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -135,6 +135,10 @@ body {
   }
 }
 
+.hidden-form {
+  display: none;
+}
+
 .inline-block {
   display: inline-block;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
 
     <%= javascript_tag do %>
       window.namespace = <%= raw @namespace.to_json %>
+      window.env = '<%= Rails.env %>'
     <% end %>
   </head>
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -344,7 +344,7 @@
     </div>
   </div>
 </div>
-<div style="display:none">
+<div class="hidden-form">
   <%= form_tag "/data_sets/dataFileUpload", method: 'post',multipart: true, id: 'datafile_form' do %>
     <%= file_field_tag 'file', { id: 'datafile_input' } %>
     <input type="hidden" name="pid" value="<%= @project.id %>">
@@ -372,7 +372,7 @@
     </div>
   </div>
 </div>
-<div style="display:none">
+<div class="hidden-form">
   <%= form_tag "/projects/#{@project.id}/templateUpload", method: 'post',multipart: true, id: 'template_file_form' do %>
     <%= file_field_tag 'file', id: 'template_file_input' %>
   <% end %>

--- a/test/integration/api_v1_test.rb
+++ b/test/integration/api_v1_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class ApiV1Test < ActionDispatch::IntegrationTest
+class ApiV1Test < IntegrationTest
   setup do
     @project_keys = %w(id featuredMediaId name url path hidden featured likeCount content timeAgoInWords createdAt ownerName ownerUrl dataSetCount fieldCount fields dataSetIDs)
     @project_keys_extended = @project_keys + ['dataSets', 'mediaObjects', 'owner']

--- a/test/integration/base_integration_test.rb
+++ b/test/integration/base_integration_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class IntegrationTest < ActionDispatch::IntegrationTest
+  include CapyHelper
+
+  setup do
+    Capybara.current_driver = :webkit
+    Capybara.default_wait_time = 2
+  end
+
+  teardown do
+    finish
+  end
+end

--- a/test/integration/bug_report_test.rb
+++ b/test/integration/bug_report_test.rb
@@ -1,17 +1,8 @@
 require 'test_helper'
-class BugReportTest < ActionDispatch::IntegrationTest
-  include CapyHelper
+require_relative 'base_integration_test'
 
+class BugReportTest < IntegrationTest
   self.use_transactional_fixtures = false
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
 
   test 'get bug report page' do
     visit '/'

--- a/test/integration/clone_project_test.rb
+++ b/test/integration/clone_project_test.rb
@@ -1,17 +1,7 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class CloneProjectTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
-
+class CloneProjectTest < IntegrationTest
   def set_cell(row, col, value)
     find(:css, ".slick-row:nth-child(#{row + 1})>.slick-cell.l#{col}").double_click
     find(:css, ".slick-row:nth-child(#{row + 1})>.slick-cell.l#{col}>input").set value

--- a/test/integration/clone_project_test.rb
+++ b/test/integration/clone_project_test.rb
@@ -30,13 +30,11 @@ class CloneProjectTest < IntegrationTest
 
     assert page.has_content?('I Like Clones'), 'Save should succeed'
     img_path = Rails.root.join('test', 'CSVs', 'nerdboy.jpg')
-    page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', img_path)
     assert page.has_content?('nerdboy.jpg'), 'File should be in list'
 
     click_on 'Das Cloning Projekt'
     img_path = Rails.root.join('test', 'CSVs', 'test.pdf')
-    page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', img_path)
     assert page.has_content?('test.pdf'), 'File should be in list'
 

--- a/test/integration/contrib_key_with_data_set_test.rb
+++ b/test/integration/contrib_key_with_data_set_test.rb
@@ -1,18 +1,8 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class ContribKeyWithDataSetTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
+class ContribKeyWithDataSetTest < IntegrationTest
   self.use_transactional_fixtures = false
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
 
   test 'website_and_API' do
     login('kcarcia@cs.uml.edu', '12345')

--- a/test/integration/delete_then_feature_mo_test.rb
+++ b/test/integration/delete_then_feature_mo_test.rb
@@ -13,7 +13,6 @@ class DeleteThenFeatureMoTest < IntegrationTest
     # upload a media object to the project
     url = page.current_path
     img_path = Rails.root.join('test', 'CSVs', 'nerdboy.jpg')
-    page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', img_path)
 
     # open a new tab/window thing
@@ -42,7 +41,6 @@ class DeleteThenFeatureMoTest < IntegrationTest
     # upload some data so we can save a visualization
     url = page.current_path
     csv_path = Rails.root.join('test', 'CSVs', 'test.csv')
-    page.execute_script "$('#template_file_form').parent().show()"
     find(:css, '#template_file_form').attach_file('file', csv_path)
     find(:css, 'button.btn-primary').click
 
@@ -56,7 +54,6 @@ class DeleteThenFeatureMoTest < IntegrationTest
     # upload a media object to the project
     url = page.current_path
     img_path = Rails.root.join('test', 'CSVs', 'nerdboy.jpg')
-    page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', img_path)
 
     # open a new tab/window thing

--- a/test/integration/delete_then_feature_mo_test.rb
+++ b/test/integration/delete_then_feature_mo_test.rb
@@ -1,17 +1,7 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class DeleteThenFeatureMoTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
-
+class DeleteThenFeatureMoTest < IntegrationTest
   test 'delete then feature project mo' do
     login 'nixon@whitehouse.gov', '12345'
 

--- a/test/integration/edit_proj_desc_test.rb
+++ b/test/integration/edit_proj_desc_test.rb
@@ -1,18 +1,11 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class EditProjDescTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
+class EditProjDescTest < IntegrationTest
   self.use_transactional_fixtures = false
 
   setup do
     @project = projects(:description_test)
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
   end
 
   def login_and_nav_to_project

--- a/test/integration/embedded_vis_test.rb
+++ b/test/integration/embedded_vis_test.rb
@@ -1,20 +1,12 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class EmbeddedVisTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
+class EmbeddedVisTest < IntegrationTest
   self.use_transactional_fixtures = false
 
   setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-
     @project_id = projects(:dessert).id
     @dataset_id = data_sets(:thanksgiving).id
-  end
-
-  teardown do
-    finish
   end
 
   test 'embedded vis page' do

--- a/test/integration/make_project_test.rb
+++ b/test/integration/make_project_test.rb
@@ -1,17 +1,7 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class MakeProjectTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
-
+class MakeProjectTest < IntegrationTest
   test 'kate makes a new project' do
     login('kcarcia@cs.uml.edu', '12345')
 

--- a/test/integration/post_news_test.rb
+++ b/test/integration/post_news_test.rb
@@ -1,8 +1,7 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class PostNewsTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
+class PostNewsTest < IntegrationTest
   self.use_transactional_fixtures = false
 
   setup do
@@ -10,12 +9,6 @@ class PostNewsTest < ActionDispatch::IntegrationTest
     @to_rename = news(:rename_this_news)
     @to_delete = news(:delete_this_news)
     @to_update = news(:update_this_news)
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
   end
 
   test 'add a news item' do

--- a/test/integration/register_test.rb
+++ b/test/integration/register_test.rb
@@ -1,17 +1,7 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class RegisterTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
-
+class RegisterTest < IntegrationTest
   test 'create a user' do
     visit '/'
     find('.navbar').click_on('Register')

--- a/test/integration/rename_vis_test.rb
+++ b/test/integration/rename_vis_test.rb
@@ -1,18 +1,8 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class RenameVisTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
+class RenameVisTest < IntegrationTest
   self.use_transactional_fixtures = false
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
 
   test 'create modify and delete a vis' do
     login('kcarcia@cs.uml.edu', '12345')

--- a/test/integration/rename_vis_test.rb
+++ b/test/integration/rename_vis_test.rb
@@ -10,7 +10,7 @@ class RenameVisTest < IntegrationTest
     visit "/projects/#{projects(:dessert).id}"
     click_on 'Visualize'
 
-    page.execute_script "$('#save-ctrls > .vis-ctrl-header').click()"
+    find('#save-ctrls > .vis-ctrl-header').click
     assert page.has_content?('Save Visualization')
     click_on 'Save Visualization'
 

--- a/test/integration/search_data_sets_test.rb
+++ b/test/integration/search_data_sets_test.rb
@@ -1,18 +1,11 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class SeachDataSetsTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
+class SeachDataSetsTest < IntegrationTest
   self.use_transactional_fixtures = false
 
   setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
     @project = projects(:one)
-  end
-
-  teardown do
-    finish
   end
 
   test 'search data sets' do

--- a/test/integration/show_user_test.rb
+++ b/test/integration/show_user_test.rb
@@ -1,18 +1,8 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class ShowUserTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
+class ShowUserTest < IntegrationTest
   self.use_transactional_fixtures = false
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 10
-  end
-
-  teardown do
-    finish
-  end
 
   test 'contributions' do
     login('nixon@whitehouse.gov', '12345')

--- a/test/integration/slickgrid_test.rb
+++ b/test/integration/slickgrid_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class SlickgridTest < ActionDispatch::IntegrationTest
-  include CapyHelper
+class SlickgridTest < IntegrationTest
 
   self.use_transactional_fixtures = false
 
@@ -23,15 +23,6 @@ class SlickgridTest < ActionDispatch::IntegrationTest
   times.each_with_index do |time, i|
     new_time = Time.local(*time).getutc
     compare_data[i]['103'] = new_time.strftime '%Y/%m/%d %H:%M:%S'
-  end
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
   end
 
   def slickgrid_enter_value(row, col, value)

--- a/test/integration/slickgrid_test.rb
+++ b/test/integration/slickgrid_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 require_relative 'base_integration_test'
 
 class SlickgridTest < IntegrationTest
-
   self.use_transactional_fixtures = false
 
   compare_data = [

--- a/test/integration/small_page_test.rb
+++ b/test/integration/small_page_test.rb
@@ -1,18 +1,8 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class SmallPageTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
+class SmallPageTest < IntegrationTest
   self.use_transactional_fixtures = false
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
 
   test 'only first paragraph' do
     login('nixon@whitehouse.gov', '12345')

--- a/test/integration/summernote_mo_test.rb
+++ b/test/integration/summernote_mo_test.rb
@@ -1,18 +1,10 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class SummernoteMoTest < ActionDispatch::IntegrationTest
+class SummernoteMoTest < IntegrationTest
   include CapyHelper
 
   self.use_transactional_fixtures = false
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
 
   test 'project_image_upload' do
     login('kcarcia@cs.uml.edu', '12345')

--- a/test/integration/tutorials_test.rb
+++ b/test/integration/tutorials_test.rb
@@ -1,17 +1,7 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class TutorialsTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
-
+class TutorialsTest < IntegrationTest
   test 'create a tutorial' do
     # Make sure a regular user cant create a tutorial
     login('kcarcia@cs.uml.edu', '12345')

--- a/test/integration/update_fields_test.rb
+++ b/test/integration/update_fields_test.rb
@@ -48,9 +48,7 @@ class UpdateFieldsTest < IntegrationTest
     # find('#template_file_upload').click
 
     csv_path = Rails.root.join('test', 'CSVs', 'dessert.csv')
-    page.execute_script "$('#template_file_form').parent().show()"
     find('#template_file_form').attach_file('file', csv_path)
-    page.execute_script "$('#template_file_form').submit()"
 
     assert page.has_content?('Please select types for each field below.')
 
@@ -70,9 +68,7 @@ class UpdateFieldsTest < IntegrationTest
     # find('#template_file_upload').click
 
     csv_path = Rails.root.join('test', 'CSVs', 'dessert.csv')
-    page.execute_script "$('#template_file_form').parent().show()"
     find('#template_file_form').attach_file('file', csv_path)
-    page.execute_script "$('#template_file_form').submit()"
 
     assert page.has_content?('Please select types for each field below.')
     find('#create_dataset').click

--- a/test/integration/update_fields_test.rb
+++ b/test/integration/update_fields_test.rb
@@ -1,17 +1,7 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class UpdateFieldsTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
-
+class UpdateFieldsTest < IntegrationTest
   test 'edit fields' do
     login('kcarcia@cs.uml.edu', '12345')
     click_on 'Projects'

--- a/test/integration/upload_data_test.rb
+++ b/test/integration/upload_data_test.rb
@@ -14,17 +14,7 @@ class UploadDataTest < IntegrationTest
     assert page.has_content?('Upload Test'), 'Not on project page.'
 
     csv_path = Rails.root.join('test', 'CSVs', 'test.csv')
-    begin
-        page.execute_script "$('#datafile_form').parent().show()"
-    rescue => e
-        puts e.inspect
-    end
     find(:css, '#datafile_form').attach_file('file', csv_path)
-    begin
-        page.execute_script "$('#datafile_form').submit()"
-    rescue => e
-        puts e.inspect
-    end
     assert page.has_content?('Match Quality')
     click_on 'Submit'
     assert page.has_css?('#vis-container'), 'Failed CSV'
@@ -37,17 +27,7 @@ class UploadDataTest < IntegrationTest
 
     # Test GPX upload
     gpx_path = Rails.root.join('test', 'CSVs', 'test.gpx')
-    begin
-        page.execute_script "$('#datafile_form').parent().show()"
-    rescue => e
-        puts e.inspect
-    end
     find(:css, '#datafile_form').attach_file('file', gpx_path)
-    begin
-        page.execute_script "$('#datafile_form').submit()"
-    rescue => e
-        e.inspect
-    end
     assert page.has_content?('Match Quality')
     all('select')[0].find(:xpath, 'option[1]').select_option
     all('select')[1].find(:xpath, 'option[1]').select_option
@@ -62,17 +42,7 @@ class UploadDataTest < IntegrationTest
 
     # Test ODS upload
     ods_path = Rails.root.join('test', 'CSVs', 'test.ods')
-    begin
-        page.execute_script "$('#datafile_form').parent().show()"
-    rescue => e
-        puts e.inspect
-    end
     find(:css, '#datafile_form').attach_file('file', ods_path)
-    begin
-        page.execute_script "$('#datafile_form').submit()"
-    rescue => e
-        puts e.inspect
-    end
     assert page.has_content?('Match Quality')
     click_on 'Submit'
     assert page.has_css?('#vis-container'), 'Failed ODS'
@@ -85,17 +55,7 @@ class UploadDataTest < IntegrationTest
 
     # Test XLS upload
     xls_path = Rails.root.join('test', 'CSVs', 'test.xls')
-    begin
-        page.execute_script "$('#datafile_form').parent().show()"
-    rescue => e
-        puts e.inspect
-    end
     find(:css, '#datafile_form').attach_file('file', xls_path)
-    begin
-        page.execute_script "$('#datafile_form').submit()"
-    rescue => e
-        puts e.inspect
-    end
     assert page.has_content?('Match Quality')
     click_on 'Submit'
     assert page.has_css?('#vis-container'), 'Failed XLS'
@@ -108,9 +68,7 @@ class UploadDataTest < IntegrationTest
 
     # Test XLSX upload
     xlsx_path = Rails.root.join('test', 'CSVs', 'test.xlsx')
-    page.execute_script "$('#datafile_form').parent().show()"
     find(:css, '#datafile_form').attach_file('file', xlsx_path)
-    page.execute_script "$('#datafile_form').submit()"
     assert page.has_content?('Match Quality')
     click_on 'Submit'
     assert page.has_css?('#vis-container'), 'Failed XLSX'
@@ -122,9 +80,7 @@ class UploadDataTest < IntegrationTest
     assert page.has_content?('Upload Test'), 'Not on project page.'
 
     csv_path = Rails.root.join('test', 'CSVs', 'invalid_test.csv')
-    page.execute_script "$('#datafile_form').parent().show()"
     find(:css, '#datafile_form').attach_file('file', csv_path)
-    page.execute_script "$('#datafile_form').submit()"
 
     assert page.has_content?('Error reading file:')
   end
@@ -151,7 +107,6 @@ class UploadDataTest < IntegrationTest
 
     # Test upload non-readable
     jpg_path = Rails.root.join('test', 'CSVs', 'nerdboy.jpg')
-    page.execute_script "$('#datafile_form').parent().show()"
     find(:css, '#datafile_form').attach_file('file', jpg_path)
     assert page.has_content?('Error reading file:')
   end
@@ -162,9 +117,7 @@ class UploadDataTest < IntegrationTest
     assert page.has_content?('Upload Test'), 'Not on project page.'
 
     ods_path = Rails.root.join('test', 'CSVs', 'test.ods')
-    page.execute_script "$('#datafile_form').parent().show()"
     find(:css, '#datafile_form').attach_file('file', ods_path)
-    page.execute_script "$('#datafile_form').submit()"
     assert page.has_content?('Match Quality')
     click_on 'Submit'
     assert page.has_css?('#vis-container'), 'Failed ODS'
@@ -195,9 +148,7 @@ class UploadDataTest < IntegrationTest
     click_on 'Submit Key'
 
     csv_path = Rails.root.join('test', 'CSVs', 'test.csv')
-    page.execute_script "$('#datafile_form').parent().show()"
     find(:css, '#datafile_form').attach_file('file', csv_path)
-    page.execute_script "$('#datafile_form').submit()"
     assert page.has_content?('Match Quality'), "Data wasn't submitted"
     fill_in 'Title', with: 'Bad Data'
 

--- a/test/integration/upload_data_test.rb
+++ b/test/integration/upload_data_test.rb
@@ -1,18 +1,11 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class UploadDataTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
+class UploadDataTest < IntegrationTest
   self.use_transactional_fixtures = false
 
   setup do
     @project = projects(:upload_test)
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
   end
 
   test 'upload csv' do
@@ -21,9 +14,17 @@ class UploadDataTest < ActionDispatch::IntegrationTest
     assert page.has_content?('Upload Test'), 'Not on project page.'
 
     csv_path = Rails.root.join('test', 'CSVs', 'test.csv')
-    page.execute_script "$('#datafile_form').parent().show()"
+    begin
+        page.execute_script "$('#datafile_form').parent().show()"
+    rescue => e
+        puts e.inspect
+    end
     find(:css, '#datafile_form').attach_file('file', csv_path)
-    page.execute_script "$('#datafile_form').submit()"
+    begin
+        page.execute_script "$('#datafile_form').submit()"
+    rescue => e
+        puts e.inspect
+    end
     assert page.has_content?('Match Quality')
     click_on 'Submit'
     assert page.has_css?('#vis-container'), 'Failed CSV'
@@ -36,9 +37,17 @@ class UploadDataTest < ActionDispatch::IntegrationTest
 
     # Test GPX upload
     gpx_path = Rails.root.join('test', 'CSVs', 'test.gpx')
-    page.execute_script "$('#datafile_form').parent().show()"
+    begin
+        page.execute_script "$('#datafile_form').parent().show()"
+    rescue => e
+        puts e.inspect
+    end
     find(:css, '#datafile_form').attach_file('file', gpx_path)
-    page.execute_script "$('#datafile_form').submit()"
+    begin
+        page.execute_script "$('#datafile_form').submit()"
+    rescue => e
+        e.inspect
+    end
     assert page.has_content?('Match Quality')
     all('select')[0].find(:xpath, 'option[1]').select_option
     all('select')[1].find(:xpath, 'option[1]').select_option
@@ -53,9 +62,17 @@ class UploadDataTest < ActionDispatch::IntegrationTest
 
     # Test ODS upload
     ods_path = Rails.root.join('test', 'CSVs', 'test.ods')
-    page.execute_script "$('#datafile_form').parent().show()"
+    begin
+        page.execute_script "$('#datafile_form').parent().show()"
+    rescue => e
+        puts e.inspect
+    end
     find(:css, '#datafile_form').attach_file('file', ods_path)
-    page.execute_script "$('#datafile_form').submit()"
+    begin
+        page.execute_script "$('#datafile_form').submit()"
+    rescue => e
+        puts e.inspect
+    end
     assert page.has_content?('Match Quality')
     click_on 'Submit'
     assert page.has_css?('#vis-container'), 'Failed ODS'
@@ -68,9 +85,17 @@ class UploadDataTest < ActionDispatch::IntegrationTest
 
     # Test XLS upload
     xls_path = Rails.root.join('test', 'CSVs', 'test.xls')
-    page.execute_script "$('#datafile_form').parent().show()"
+    begin
+        page.execute_script "$('#datafile_form').parent().show()"
+    rescue => e
+        puts e.inspect
+    end
     find(:css, '#datafile_form').attach_file('file', xls_path)
-    page.execute_script "$('#datafile_form').submit()"
+    begin
+        page.execute_script "$('#datafile_form').submit()"
+    rescue => e
+        puts e.inspect
+    end
     assert page.has_content?('Match Quality')
     click_on 'Submit'
     assert page.has_css?('#vis-container'), 'Failed XLS'

--- a/test/integration/upload_media_test.rb
+++ b/test/integration/upload_media_test.rb
@@ -12,13 +12,10 @@ class UploadMediaTest < IntegrationTest
     visit "/tutorials/#{tut_id}"
     assert page.has_content? 'Media'
     img_path = Rails.root.join('test', 'CSVs', 'nerdboy.jpg')
-    page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', img_path)
     assert page.has_content?('nerdboy.jpg'), 'File should be in list'
     find('.media_edit').click
     assert page.has_content?('nerdboy.jpg'), 'Should have gone to edit page'
-
-    page.execute_script 'window.confirm = function () { return true }'
 
     # Upload media to news
     proj_id = projects(:media_test).id
@@ -26,7 +23,6 @@ class UploadMediaTest < IntegrationTest
     visit "/news/#{news_id}"
     assert page.has_content? 'Media'
     img_path = Rails.root.join('test', 'CSVs', 'nerdboy.jpg')
-    page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', img_path)
     assert page.has_content?('nerdboy.jpg'), 'File should be in list'
     find('.media_edit').click
@@ -42,7 +38,6 @@ class UploadMediaTest < IntegrationTest
     visit "/projects/#{proj_id}"
     assert page.has_content? 'Media'
     img_path = Rails.root.join('test', 'CSVs', 'nerdboy.jpg')
-    page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', img_path)
     assert page.has_content?('nerdboy.jpg'), 'File should be in list'
 
@@ -50,7 +45,6 @@ class UploadMediaTest < IntegrationTest
     visit "/projects/#{proj_id}"
     assert page.has_content? 'Media'
     text_path = Rails.root.join('test', 'CSVs', 'test.txt')
-    page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', text_path)
     assert page.has_content?('test.txt'), 'File should be in list'
 
@@ -58,7 +52,6 @@ class UploadMediaTest < IntegrationTest
     visit "/projects/#{proj_id}"
     assert page.has_content? 'Media'
     pdf_path = Rails.root.join('test', 'CSVs', 'test.pdf')
-    page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', pdf_path)
     assert page.has_content?('test.pdf'), 'File should be in list'
 
@@ -66,7 +59,6 @@ class UploadMediaTest < IntegrationTest
     visit "/projects/#{proj_id}"
     assert page.has_content? 'Media'
     ods_path = Rails.root.join('test', 'CSVs', 'test.ods')
-    page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', ods_path)
     assert page.has_content?('test.ods'), 'File should be in list'
 
@@ -74,7 +66,6 @@ class UploadMediaTest < IntegrationTest
     visit "/projects/#{proj_id}"
     assert page.has_content? 'Media'
     html_path = Rails.root.join('test', 'CSVs', 'test.html')
-    page.execute_script "$('#upload').show()"
     find('.upload_media form').attach_file('upload', html_path)
     assert page.has_no_content?('test.html'), 'File should be in list'
     assert page.has_content?('Sorry, html is not a supported file type.'), 'Unsupported file type failed.'

--- a/test/integration/upload_media_test.rb
+++ b/test/integration/upload_media_test.rb
@@ -1,18 +1,8 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class UploadMediaTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
+class UploadMediaTest < IntegrationTest
   self.use_transactional_fixtures = false
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
 
   test 'upload media' do
     login('nixon@whitehouse.gov', '12345')

--- a/test/integration/upload_zip_test.rb
+++ b/test/integration/upload_zip_test.rb
@@ -14,17 +14,7 @@ class UploadZipTest < IntegrationTest
     assert page.has_content?('one'), 'Not on project page.'
 
     zip_path = Rails.root.join('test', 'CSVs', 'upload.zip')
-    begin
-      page.execute_script "$('#datafile_form').parent().show()"
-    rescue => e
-      puts e.inspect
-    end
     find('#datafile_form').attach_file('file', zip_path)
-    begin
-      page.execute_script "$('#datafile_form').submit()"
-    rescue => e
-      puts e.inspect
-    end
     assert page.has_content?('Match Quality')
     click_on 'Submit'
     assert page.has_content?('one'), 'Not on project page after upload.'
@@ -38,9 +28,7 @@ class UploadZipTest < IntegrationTest
     assert page.has_content?('one'), 'Not on project page.'
 
     zip_path = Rails.root.join('test', 'CSVs', 'img.zip')
-    page.execute_script "$('#datafile_form').parent().show()"
     find('#datafile_form').attach_file('file', zip_path)
-    page.execute_script "$('#datafile_form').submit()"
     assert page.has_content?('Error reading file')
   end
 end

--- a/test/integration/upload_zip_test.rb
+++ b/test/integration/upload_zip_test.rb
@@ -1,18 +1,11 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class UploadZipTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
+class UploadZipTest < IntegrationTest
   self.use_transactional_fixtures = false
 
   setup do
     @project = projects(:one)
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
   end
 
   test 'upload zip with csv files' do
@@ -21,9 +14,17 @@ class UploadZipTest < ActionDispatch::IntegrationTest
     assert page.has_content?('one'), 'Not on project page.'
 
     zip_path = Rails.root.join('test', 'CSVs', 'upload.zip')
-    page.execute_script "$('#datafile_form').parent().show()"
+    begin
+      page.execute_script "$('#datafile_form').parent().show()"
+    rescue => e
+      puts e.inspect
+    end
     find('#datafile_form').attach_file('file', zip_path)
-    page.execute_script "$('#datafile_form').submit()"
+    begin
+      page.execute_script "$('#datafile_form').submit()"
+    rescue => e
+      puts e.inspect
+    end
     assert page.has_content?('Match Quality')
     click_on 'Submit'
     assert page.has_content?('one'), 'Not on project page after upload.'

--- a/test/integration/user_sorting_test.rb
+++ b/test/integration/user_sorting_test.rb
@@ -1,17 +1,7 @@
 require 'test_helper'
+require_relative 'base_integration_test'
 
-class UserSortingTest < ActionDispatch::IntegrationTest
-  include CapyHelper
-
-  setup do
-    Capybara.current_driver = :webkit
-    Capybara.default_wait_time = 2
-  end
-
-  teardown do
-    finish
-  end
-
+class UserSortingTest < IntegrationTest
   test 'use sorting' do
     # Navigate to the user's page
     login('kcarcia@cs.uml.edu', '12345')


### PR DESCRIPTION
* adds some code that makes forms visible during tests (because Capybara doesn't like that)
* I know this is bad but it's better than failing tests and that's literally the only other option
* adds a base integration test that sets the default wait time for every test, so the default is an actual default and not affected by the order of test execution
* deleted all the calls to `page.execute_script` with the above changes and everything passes now