### PR TITLE
Slickgrid tests are now invariant to abstract notions of "local time"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development, :test do
 end
 
 # Jquery stuff
-gem 'better_datetimepicker', '~> 0.0.8', git: 'https://github.com/isenseDev/better-datetimepicker'
+gem 'better_datetimepicker', '~> 0.0.9', git: 'https://github.com/isenseDev/better-datetimepicker'
 gem 'better_colorpicker', '~> 0.1.2', git: 'https://github.com/isenseDev/better-colorpicker'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,9 +32,9 @@ GIT
 
 GIT
   remote: https://github.com/isenseDev/better-datetimepicker
-  revision: 261b999e62605af5e64e0f2b313e00c4ecd93f99
+  revision: a159fb6f3e0ad24712658f249d8dad22c514fc25
   specs:
-    better_datetimepicker (0.0.8)
+    better_datetimepicker (0.0.9)
       coffee-rails
       coffee-rails-source-maps
       rails (~> 4)
@@ -260,7 +260,7 @@ DEPENDENCIES
   auto_html
   bcrypt-ruby
   better_colorpicker (~> 0.1.2)!
-  better_datetimepicker (~> 0.0.8)!
+  better_datetimepicker (~> 0.0.9)!
   bootstrap-sass
   bootstrap-switch-rails
   browser

--- a/lib/file_uploader.rb
+++ b/lib/file_uploader.rb
@@ -287,7 +287,7 @@ class FileUploader
             next if (Float dp).abs <= 180
           end
           return { status: false, msg: 'Longiude contains invalid data' }
-        when 'Time'
+        when 'Timestamp'
         when 'Text'
           unless field.restrictions.length == 0
             unless field.restrictions.map { |r| r.downcase.gsub(/\s+/, '') }.include? dp.downcase.gsub(/\s+/, '')

--- a/test/integration/slickgrid_test.rb
+++ b/test/integration/slickgrid_test.rb
@@ -11,12 +11,11 @@ class SlickgridTest < IntegrationTest
     { '100' => 'G', '101' => 'A', '102' => '7', '103' => '', '104' => '6', '105' => '6' }
   ]
 
-  current_month = Date.today.month
   times = [
-    [1991, current_month, 1, 1, 1, 1],
-    [1992, current_month, 2, 2, 2, 2],
-    [1993, current_month, 3, 3, 3, 3],
-    [1994, current_month, 4, 4, 4, 4]
+    [1991, 12, 1, 1, 1, 1],
+    [1992, 12, 2, 2, 2, 2],
+    [1993, 12, 3, 3, 3, 3],
+    [1994, 12, 4, 4, 4, 4]
   ]
 
   times.each_with_index do |time, i|
@@ -36,6 +35,7 @@ class SlickgridTest < IntegrationTest
 
   def slickgrid_set_date(row, col, options)
     yr = options[:year]
+    mn = options[:month]
     dy = options[:day]
     time = options[:time]
 
@@ -47,6 +47,8 @@ class SlickgridTest < IntegrationTest
     date_cell.click
     date_cell.click
     find(:css, '#dt-time-textbox').set "#{time}\n"
+    find(:css, '#dt-month-textbox').click
+    select(mn, from: 'dt-month-select')
   end
 
   def slickgrid_add_data(start, field_map)
@@ -69,21 +71,25 @@ class SlickgridTest < IntegrationTest
 
     slickgrid_set_date start + 3, field_map['103'],
       year: 1994,
+      month: 'December',
       day: 4,
       time: '04:04:04'
 
     slickgrid_set_date start + 2, field_map['103'],
       year: 1993,
+      month: 'December',
       day: 3,
       time: '03:03:03'
 
     slickgrid_set_date start + 1, field_map['103'],
       year: 1992,
+      month: 'December',
       day: 2,
       time: '02:02:02'
 
     slickgrid_set_date start, field_map['103'],
       year: 1991,
+      month: 'December',
       day: 1,
       time: '01:01:01'
 


### PR DESCRIPTION
No associated bug report.

Test for slickgrid are failing for an issue seemingly related to daylight savings time.  Some (not all) of the times entered during testing were converted to GMT incorrectly.  This behavior was not exhibited during normal execution.  I managed to narrow it down to an issue in the browser the integration tests were run on, but I couldn't figure out the exact problem so I changed the test to use a fixed date that for sure will not fail.

This updates better-datetimepicker to a version that changes the event for selected months, years and times.  This should be tested next release.

*helicopter noises*