### PR TITLE
Fixed issue ps2276 - project 891 breaks vis rendering

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -549,35 +549,37 @@ $ ->
         # Restore saved regressions if they exist
         fs = globals.configs.fieldSelection
         for regr in @configs.savedRegressions
-          groupsIntersect =
-            (g in data.groupSelection for g in regr.groups).reduce(
-              ((p, c) -> p and c), true)
+          # this if statement is a fix that prevents certain projects from halting during rendering.
+          if typeof regr.groups != 'undefined'
+            groupsIntersect =
+              (g in data.groupSelection for g in regr.groups).reduce(
+                ((p, c) -> p and c), true)
 
-          enabled = regr.xAxis is @configs.xAxis and groupsIntersect and
-            fs.indexOf(regr.yAxis) isnt -1
+            enabled = regr.xAxis is @configs.xAxis and groupsIntersect and
+              fs.indexOf(regr.yAxis) isnt -1
 
-          # Calculate the hypothesis function
-          func =
-            if regr.type is globals.REGRESSION.SYMBOLIC
-              new Function("x", regr.func)
-            else
-              new Function("x, P", regr.func)
+            # Calculate the hypothesis function
+            func =
+              if regr.type is globals.REGRESSION.SYMBOLIC
+                new Function("x", regr.func)
+              else
+                new Function("x, P", regr.func)
 
-          # Calculate the series
-          params = regr.parameters
-          unless regr.type is globals.REGRESSION.SYMBOLIC
-            # Convert parameters from strings to numbers
-            params = for i in [0...regr.parameters.length]
-              parseFloat(regr.parameters[i])
+            # Calculate the series
+            params = regr.parameters
+            unless regr.type is globals.REGRESSION.SYMBOLIC
+              # Convert parameters from strings to numbers
+              params = for i in [0...regr.parameters.length]
+                parseFloat(regr.parameters[i])
 
-          series =
-            globals.getRegressionSeries(func, params, Number(regr.r2),
-              regr.type, [@configs.xBounds.min, @configs.xBounds.max],
-              regr.name, regr.dashStyle, regr.id, regr.tooltip, false)[3]
+            series =
+              globals.getRegressionSeries(func, params, Number(regr.r2),
+                regr.type, [@configs.xBounds.min, @configs.xBounds.max],
+                regr.name, regr.dashStyle, regr.id, regr.tooltip, false)[3]
 
-          # Add the regression to the chart
-          if enabled then @chart.addSeries(series)
-          @addRegressionToTable(regr, enabled)
+            # Add the regression to the chart
+            if enabled then @chart.addSeries(series)
+            @addRegressionToTable(regr, enabled)
 
         # Create a new regression
         $('#draw-regr-btn').click =>


### PR DESCRIPTION
#2276 
Basically, one of the objects in the scatterplot vis was undefined, so when the script tried to access it, it threw an Uncaught TypeError, so it halted the rendering of the page.