### PR TITLE
Now able to trim leading and trailing whitespace when manually entering number fields

### DIFF
--- a/test/integration/slickgrid_test.rb
+++ b/test/integration/slickgrid_test.rb
@@ -139,6 +139,17 @@ class SlickgridTest < IntegrationTest
     assert_similar_arrays compare_data, dataset.data
   end
 
+  test 'slickgrid enter number with spaces' do
+    login 'nixon@whitehouse.gov', '12345'
+
+    dataset = DataSet.find_by_name 'Slickgrid Data set 1'
+    visit "/data_sets/#{dataset.id}/edit"
+    find(:css, '.slick-row:nth-child(5)>.slick-cell.l1').click
+    find(:css, '.slick-row:nth-child(5)>.slick-cell.l1>input').set ' 117 '
+    find(:css, '#edit_table_add_1').click
+    assert page.has_no_content?('Please enter a valid number.'), 'Number with spaces failed.'
+  end
+
   test 'slickgrid edit data set' do
     login 'nixon@whitehouse.gov', '12345'
 

--- a/vendor/assets/javascripts/slickgrid-editors/slickgrid-decimal.coffee
+++ b/vendor/assets/javascripts/slickgrid-editors/slickgrid-decimal.coffee
@@ -25,11 +25,11 @@
     form.val()
   loadValue: (item) ->
     loadValue = item[args.column.field] || ''
-    form.val loadValue
+    form.val loadValue.trim()
   applyValue: (item, state) ->
     item[args.column.field] = state
   validate: ->
-    isNumber = /^(?:(?:\+|-)?(?:\d*\.\d+|\d+))?$/
+    isNumber = /^\s*(?:(?:\+|-)?(?:\d*\.\d+|\d+))?\s*$/
     if isNumber.test form.val()
       {valid: true, msg: null}
     else


### PR DESCRIPTION
#2287
Had to update the regular expression and add a call to .trim() in slickgrid-decimal.coffee.