### PR TITLE
Fixes a test that broke from material design

### DIFF
--- a/test/integration/number_of_data_sets_test.rb
+++ b/test/integration/number_of_data_sets_test.rb
@@ -1,15 +1,15 @@
 require 'test_helper'
+require 'capybara-screenshot'
 require_relative 'base_integration_test'
 
 class UploadDataTest < IntegrationTest
   self.use_transactional_fixtures = false
 
-  setup do
-    @project = projects(:lots_of_data_sets)
-  end
-
   test 'correct number of data sets' do
+    @project = projects(:lots_of_data_sets)
+
     visit project_path(@project)
+    screenshot_and_open_image
     assert page.has_content?('Lots of Data Sets'), 'Not on project page.'
 
     first('.mdl-checkbox ').click

--- a/test/integration/number_of_data_sets_test.rb
+++ b/test/integration/number_of_data_sets_test.rb
@@ -10,7 +10,6 @@ class UploadDataTest < IntegrationTest
 
   test 'correct number of data sets' do
     visit project_path(@project)
-
     assert page.has_content?('Lots of Data Sets'), 'Not on project page.'
 
     first('.mdl-checkbox ').click

--- a/test/integration/number_of_data_sets_test.rb
+++ b/test/integration/number_of_data_sets_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'capybara-screenshot'
 require_relative 'base_integration_test'
 
 class UploadDataTest < IntegrationTest
@@ -9,7 +8,6 @@ class UploadDataTest < IntegrationTest
     @project = projects(:lots_of_data_sets)
 
     visit project_path(@project)
-    screenshot_and_open_image
     assert page.has_content?('Lots of Data Sets'), 'Not on project page.'
 
     first('.mdl-checkbox ').click

--- a/test/integration/number_of_data_sets_test.rb
+++ b/test/integration/number_of_data_sets_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'capybara-screenshot'
 require_relative 'base_integration_test'
 
 class UploadDataTest < IntegrationTest
@@ -11,8 +10,6 @@ class UploadDataTest < IntegrationTest
 
   test 'correct number of data sets' do
     visit project_path(@project)
-
-    screenshot_and_open_image
 
     assert page.has_content?('Lots of Data Sets'), 'Not on project page.'
 

--- a/test/integration/number_of_data_sets_test.rb
+++ b/test/integration/number_of_data_sets_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'capybara-screenshot'
 require_relative 'base_integration_test'
 
 class UploadDataTest < IntegrationTest
@@ -10,10 +11,13 @@ class UploadDataTest < IntegrationTest
 
   test 'correct number of data sets' do
     visit project_path(@project)
+
+    screenshot_and_open_image
+
     assert page.has_content?('Lots of Data Sets'), 'Not on project page.'
 
-    all('input[type="checkbox"]')[0].click
-    all('input[type="checkbox"]')[1].click
+    first('.mdl-checkbox ').click
+    all('.mdl-checkbox ').last.click
 
     click_on('Visualize')
 


### PR DESCRIPTION
No associated bug.
Last release had a test that clicked a check box. Material design was merged at the same time and it broke the way the test found the check boxes. This fixes the test so it finds the check boxes correctly.