### PR TITLE
fixes map checkbox

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -244,6 +244,9 @@ $ ->
         $('#vis-ctrls').find(".mdl-radio").each (i,j) ->
           componentHandler.upgradeElement($(j)[0]);
 
+        $('#vis-ctrls').find(".mdl-slider").each (i,j) ->
+          componentHandler.upgradeElement($(j)[0]);
+
         # Initialize checked and make y axis checkbox/radio handler
         if radio
           # Set the current display field
@@ -376,6 +379,9 @@ $ ->
           componentHandler.upgradeElement($(j)[0]);
 
         $('#vis-ctrls').find(".mdl-radio").each (i,j) ->
+          componentHandler.upgradeElement($(j)[0]);
+
+        $('#vis-ctrls').find(".mdl-slider").each (i,j) ->
           componentHandler.upgradeElement($(j)[0]);
 
         # Initialize and track the status of this control panel

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -285,13 +285,10 @@ $ ->
 
         # Adds material design
         $('#vis-ctrls').find(".mdl-checkbox").each (i,j) ->
-          componentHandler.upgradeElement($(j)[0]);
+          componentHandler.upgradeElement($(j)[0])
 
         $('#vis-ctrls').find(".mdl-radio").each (i,j) ->
-          componentHandler.upgradeElement($(j)[0]);
-
-        $('#vis-ctrls').find(".mdl-slider").each (i,j) ->
-          componentHandler.upgradeElement($(j)[0]);
+          componentHandler.upgradeElement($(j)[0])
 
         # Initialize and track the status of this control panel
         globals.configs.toolsOpen ?= false
@@ -334,6 +331,10 @@ $ ->
             @update()
           else
             alert('Entered bin size would result in too many bins.')
+
+        # Adds Material Design to slider
+        $('#vis-ctrls').find(".mdl-slider").each (i,j) ->
+          componentHandler.upgradeElement($(j)[0])
 
       drawControls: ->
         super()

--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -445,6 +445,7 @@ $ ->
         @drawSaveControls()
 
       drawToolControls: ->
+
         inctx =
           radius: @configs.heatmapRadius
           displayMarkers:
@@ -489,10 +490,10 @@ $ ->
 
         # Add material design
         $('#vis-ctrls').find(".mdl-checkbox").each (i,j) ->
-          componentHandler.upgradeElement($(j)[0]);
+          componentHandler.upgradeElement($(j)[0])
 
         $('#vis-ctrls').find(".mdl-radio").each (i,j) ->
-          componentHandler.upgradeElement($(j)[0]);
+          componentHandler.upgradeElement($(j)[0])
 
         # Initialize and track the status of this control panel
         globals.configs.toolsOpen ?= false
@@ -506,17 +507,20 @@ $ ->
           @delayedUpdate()
 
         # Checkboxes
-        $('#ckbx-display-markers').prop('checked', @configs.visibleMarkers)
+        if @configs.visibleMarkers
+          $('#ckbx-lbl-display-markers')[0].MaterialCheckbox.check()
         $('#ckbx-display-markers').click (e) =>
           @configs.visibleMarkers = e.target.checked
           @delayedUpdate()
 
-        $('#ckbx-connect-markers').prop('checked', @configs.visibleLines)
+        if @configs.visibleLines
+          $('#ckbx-lbl-connect-markers')[0].MaterialCheckbox.check()
         $('#ckbx-connect-markers').click (e) =>
           @configs.visibleLines = e.target.checked
           @delayedUpdate()
 
-        $('#ckbx-cluster-markers').prop('checked', @configs.visibleClusters)
+        if @configs.visibleClusters
+          $('#ckbx-lbl-cluster-markers')[0].MaterialCheckbox.check()
         $('#ckbx-cluster-markers').click (e) =>
           @configs.visibleClusters = e.target.checked
           @start()
@@ -562,6 +566,9 @@ $ ->
           $('#heatmap-slider').val(Math.log(@configs.heatmapRadius) /
             Math.log(10))
           @delayedUpdate()
+
+        $('#vis-ctrls').find(".mdl-slider").each (i,j) ->
+          componentHandler.upgradeElement($(j)[0])
 
       resize: (newWidth, newHeight, duration) ->
         func = =>


### PR DESCRIPTION
#2326 Fixes the check boxes for map. 

I also fixed the slider on map so that it is always Material Design. It was previously losing its styling when switching to another vis and switching back.