### PR TITLE
Group by Number Fields for Pie Chart

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -142,8 +142,10 @@ $ ->
 
       drawControls: ->
         super()
-
-        @drawGroupControls(data.textFields)
+        # Remove group by number fields, only for pie chart
+        groups = $.extend(true, [], data.textFields)
+        groups.splice(2, 1)
+        @drawGroupControls(groups)
         @drawYAxisControls(globals.configs.fieldSelection,
           data.normalFields.slice(1), false)
         @drawToolControls(true, true)

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -144,7 +144,7 @@ $ ->
         super()
         # Remove group by number fields, only for pie chart
         groups = $.extend(true, [], data.textFields)
-        groups.splice(2, 1)
+        groups.splice(data.NUMBER_FIELDS_FIELD - 1, 1)
         @drawGroupControls(groups)
         @drawYAxisControls(globals.configs.fieldSelection,
           data.normalFields.slice(1), false)

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -124,6 +124,32 @@ $ ->
 
         return gData
 
+
+      ###
+      Calculate data to be displayed subject to analysis type
+      Returns an object of key-value pairs of the form { groupId, value }
+      This function is used when the groups are fields.
+      ###
+      getFieldData: () ->
+        fData = {}
+        dp = globals.getData(true, globals.configs.activeFilters)
+
+        analysisMethod =
+          switch @configs.analysisType
+            when @ANALYSISTYPE_TOTAL      then data.getTotal
+            when @ANALYSISTYPE_MAX        then data.getMax
+            when @ANALYSISTYPE_MIN        then data.getMin
+            when @ANALYSISTYPE_MEAN       then data.getMean
+            when @ANALYSISTYPE_MEAN_ERROR then data.getMean
+            when @ANALYSISTYPE_MEDIAN     then data.getMedian
+            when @ANALYSISTYPE_COUNT      then data.getCount
+
+        hiddenFields = data.fields.map((field) -> field.fieldID).filter((id) -> id == -1).length
+        for fieldId, index in data.groupSelection
+          fData[index] = analysisMethod.call(data, fieldId + hiddenFields, null, dp)
+
+        return fData
+
       ###
       Draw clipping controls
       ###
@@ -417,7 +443,6 @@ $ ->
           gid =
             if e.target then Number(e.target.value)
             else Number(e.srcElement.value)
-
           data.setGroupIndex(gid)
           globals.configs.groupById = gid
           data.groupSelection = for vals, keys in data.groups

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -764,6 +764,9 @@ $ ->
       Should destroy the chart, hide its canvas and remove controls.
       ###
       end: ->
+        if "Pie" in data.relVis and globals.configs.groupById == data.NUMBER_FIELDS_FIELD
+          $('#group-by').val(data.COMBINED_FIELD).change()
+          
         if @chart?
           @chart.destroy()
           @chart = undefined

--- a/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
+++ b/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
@@ -171,8 +171,7 @@ $ ->
         rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
       else
         if typeof groupIndices is 'number' then groupIndices = [groupIndices]
-        rawData = dp
-        rawData.map (p) -> p[fieldIndex]
+        rawData = dp.map (p) -> p[fieldIndex]
 
       if rawData.length > 0
         result = rawData.reduce (a,b) -> Math.max(a, b)
@@ -189,8 +188,8 @@ $ ->
         if typeof groupIndices is 'number' then groupIndices = [groupIndices]
         rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
       else
-        rawData = dp
-        rawData.map (p) -> p[fieldIndex]
+        rawData = dp.map (p) -> p[fieldIndex]
+
       if rawData.length > 0
         result = rawData.reduce (a,b) -> Math.min(a, b)
         data.precisionFilter(result)
@@ -206,8 +205,7 @@ $ ->
         if typeof groupIndices is 'number' then groupIndices = [groupIndices]
         rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
       else
-        rawData = dp
-        rawData.map (p) -> p[fieldIndex]
+        rawData = dp.map (p) -> p[fieldIndex]
 
       if rawData.length > 0
         result = (rawData.reduce (a,b) -> a + b) / rawData.length
@@ -224,8 +222,7 @@ $ ->
         if typeof groupIndices is 'number' then groupIndices = [groupIndices]
         rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
       else
-        rawData = dp
-        rawData.map (p) -> p[fieldIndex]
+        rawData = dp.map (p) -> p[fieldIndex]
 
       rawData.sort (a, b) ->
         if a < b then -1 else 1
@@ -246,10 +243,9 @@ $ ->
     data.getCount = (fieldIndex, groupIndices, dp) ->
       if groupIndices?
         if typeof groupIndices is 'number' then groupIndices = [groupIndices]
-        rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
+        dataCount = @multiGroupSelector(fieldIndex, groupIndices, dp).length
       else
-        rawData = dp
-        rawData.map (p) -> p[fieldIndex]
+        dataCount = (dp.map (p) -> p[fieldIndex]).length
 
       return dataCount
 
@@ -262,8 +258,7 @@ $ ->
         if typeof groupIndices is 'number' then groupIndices = [groupIndices]
         rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
       else
-        rawData = dp
-        rawData = rawData.map (p) -> p[fieldIndex]
+        rawData = dp.map (p) -> p[fieldIndex]
 
       if rawData.length > 0
         total = 0

--- a/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
+++ b/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
@@ -57,6 +57,7 @@ $ ->
     data.DATA_POINT_ID_FIELD = 0
     data.DATASET_NAME_FIELD = 1
     data.COMBINED_FIELD = 2
+    data.NUMBER_FIELDS_FIELD = 3
 
     data.types ?=
       TIME: 1
@@ -165,8 +166,13 @@ $ ->
     All included datapoints must pass the given filter (defaults to all datapoints).
     ###
     data.getMax = (fieldIndex, groupIndices, dp) ->
-      if typeof groupIndices is 'number' then groupIndices = [groupIndices]
-      rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
+      if groupIndices?
+        if typeof groupIndices is 'number' then groupIndices = [groupIndices]
+        rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
+      else
+        if typeof groupIndices is 'number' then groupIndices = [groupIndices]
+        rawData = dp
+        rawData.map (p) -> p[fieldIndex]
 
       if rawData.length > 0
         result = rawData.reduce (a,b) -> Math.max(a, b)
@@ -179,9 +185,12 @@ $ ->
     All included datapoints must pass the given filter (defaults to all datapoints).
     ###
     data.getMin = (fieldIndex, groupIndices, dp) ->
-      if typeof groupIndices is 'number' then groupIndices = [groupIndices]
-      rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
-
+      if groupIndices?
+        if typeof groupIndices is 'number' then groupIndices = [groupIndices]
+        rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
+      else
+        rawData = dp
+        rawData.map (p) -> p[fieldIndex]
       if rawData.length > 0
         result = rawData.reduce (a,b) -> Math.min(a, b)
         data.precisionFilter(result)
@@ -193,8 +202,12 @@ $ ->
     All included datapoints must pass the given filter (defaults to all datapoints).
     ###
     data.getMean = (fieldIndex, groupIndices, dp) ->
-      if typeof groupIndices is 'number' then groupIndices = [groupIndices]
-      rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
+      if groupIndices?
+        if typeof groupIndices is 'number' then groupIndices = [groupIndices]
+        rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
+      else
+        rawData = dp
+        rawData.map (p) -> p[fieldIndex]
 
       if rawData.length > 0
         result = (rawData.reduce (a,b) -> a + b) / rawData.length
@@ -207,9 +220,13 @@ $ ->
     All included datapoints must pass the given filter (defaults to all datapoints).
     ###
     data.getMedian = (fieldIndex, groupIndices, dp) ->
-      if typeof groupIndices is 'number' then groupIndices = [groupIndices]
+      if groupIndices?
+        if typeof groupIndices is 'number' then groupIndices = [groupIndices]
+        rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
+      else
+        rawData = dp
+        rawData.map (p) -> p[fieldIndex]
 
-      rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
       rawData.sort (a, b) ->
         if a < b then -1 else 1
       mid = Math.floor (rawData.length / 2)
@@ -227,8 +244,12 @@ $ ->
     All included datapoints must pass the given filter (defaults to all datapoints).
     ###
     data.getCount = (fieldIndex, groupIndices, dp) ->
-      if typeof groupIndices is 'number' then groupIndices = [groupIndices]
-      dataCount = @multiGroupSelector(fieldIndex, groupIndices, dp).length
+      if groupIndices?
+        if typeof groupIndices is 'number' then groupIndices = [groupIndices]
+        rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
+      else
+        rawData = dp
+        rawData.map (p) -> p[fieldIndex]
 
       return dataCount
 
@@ -237,8 +258,12 @@ $ ->
     All included datapoints must pass the given filter (defaults to all datapoints).
     ###
     data.getTotal = (fieldIndex, groupIndices, dp) ->
-      if typeof groupIndices is 'number' then groupIndices = [groupIndices]
-      rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
+      if groupIndices?
+        if typeof groupIndices is 'number' then groupIndices = [groupIndices]
+        rawData = @multiGroupSelector(fieldIndex, groupIndices, dp)
+      else
+        rawData = dp
+        rawData = rawData.map (p) -> p[fieldIndex]
 
       if rawData.length > 0
         total = 0
@@ -254,7 +279,8 @@ $ ->
     ###
     data.setGroupIndex = (gIndex) ->
       @groups = @makeGroups(gIndex)
-      @dataPoints = @setIndexFromGroups(gIndex)
+      if gIndex != data.NUMBER_FIELDS_FIELD
+        @dataPoints = @setIndexFromGroups(gIndex)
       globals.updateColorSlots()
 
     ###
@@ -278,15 +304,21 @@ $ ->
     Gets a list of unique, non-null, stringified vals from the group field index.
     ###
     data.makeGroups = (gIndex) ->
-
       result = {}
 
-      for dp in @dataPoints
-        if dp[gIndex] isnt null
-          result[String(dp[gIndex]).toLowerCase()] = true
+      # If group by number fields, get the number fields
+      if gIndex == data.NUMBER_FIELDS_FIELD
+        groups = []
+        for f in data.normalFields
+          if data.fields[f].fieldID != -1
+            groups.push(data.fields[f].fieldName)
+      else
+        for dp in @dataPoints
+          if dp[gIndex] isnt null
+            result[String(dp[gIndex]).toLowerCase()] = true
 
-      groups = for keys of result
-        keys
+        groups = for keys of result
+          keys
 
       groups.sort()
 

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -337,7 +337,10 @@ $ ->
 
       drawControls: ->
         super()
-        @drawGroupControls(data.textFields)
+        # Remove group by number fields, only for pie chart
+        groups = $.extend(true, [], data.textFields)
+        groups.splice(2, 1)
+        @drawGroupControls(groups)
 
         handler = (selected, selFields) =>
           @yAxisRadioHandler(selected, selFields)

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -339,7 +339,7 @@ $ ->
         super()
         # Remove group by number fields, only for pie chart
         groups = $.extend(true, [], data.textFields)
-        groups.splice(2, 1)
+        groups.splice(data.NUMBER_FIELDS_FIELD - 1, 1)
         @drawGroupControls(groups)
 
         handler = (selected, selFields) =>

--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -439,6 +439,9 @@ $ ->
 
       drawControls: ->
         super()
+        # Remove group by number fields
+        groups = $.extend(true, [], data.textFields)
+        groups.splice(2, 1)
         @drawGroupControls(data.textFields, true)
         @drawToolControls()
         @drawClippingControls()

--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -441,8 +441,8 @@ $ ->
         super()
         # Remove group by number fields
         groups = $.extend(true, [], data.textFields)
-        groups.splice(2, 1)
-        @drawGroupControls(data.textFields, true)
+        groups.splice(data.NUMBER_FIELDS_FIELD - 1, 1)
+        @drawGroupControls(groups, true)
         @drawToolControls()
         @drawClippingControls()
         @drawSaveControls()

--- a/app/assets/javascripts/visualizations/highvis/pie.coffee
+++ b/app/assets/javascripts/visualizations/highvis/pie.coffee
@@ -48,7 +48,11 @@ $ ->
 
         @configs.selectName = data.fields[globals.configs.groupById].fieldName
 
-        groupedData = @getGroupedData(@configs.displayField)
+        if globals.configs.groupById == 3
+          groupedData = @getFieldData(@configs.displayField)
+        else
+          groupedData = @getGroupedData(@configs.displayField)
+
         displayData = for gid, val of groupedData
           ret =
             y: if val < 0 then 0 else val            # for calculations
@@ -66,7 +70,10 @@ $ ->
         options =
           data: displayData
           colors: displayColors
-        @chart.setTitle { text: "#{data.fields[@configs.displayField].fieldName} grouped by #{@configs.selectName}" }
+        if globals.configs.groupById == data.NUMBER_FIELDS_FIELD
+          @chart.setTitle { text: "#{@configs.selectName}" }
+        else
+          @chart.setTitle { text: "#{data.fields[@configs.displayField].fieldName} grouped by #{@configs.selectName}" }
         @chart.addSeries options, false
 
         @chart.redraw()
@@ -88,8 +95,11 @@ $ ->
               str  = "<div style='width:100%;text-align:center;color:#{@series.color};"
               str += "margin-bottom:5px'> #{@point.name}</div>"
               str += "<table>"
-              str += "<tr><td>#{data.fields[self.configs.displayField].fieldName}
-                 (#{self.analysisTypeNames[self.configs.analysisType]}): "
+              if globals.configs.groupById == data.NUMBER_FIELDS_FIELD
+                str += "<tr><td>#{self.analysisTypeNames[self.configs.analysisType]}: "
+              else
+                str += "<tr><td>#{data.fields[self.configs.displayField].fieldName}
+                   (#{self.analysisTypeNames[self.configs.analysisType]}): "
               str += "</td><td><strong>#{@point.val} \
               #{fieldUnit(data.fields[self.configs.displayField], false)}</strong></td></tr>"
               str += "</table>"
@@ -107,9 +117,10 @@ $ ->
       drawControls: ->
         super()
         @drawGroupControls(data.textFields)
-        @drawYAxisControls(globals.configs.fieldSelection,
-          data.normalFields.slice(1), true, 'Fields', @configs.displayField,
-          @yAxisRadioHandler)
+        if globals.configs.groupById != data.NUMBER_FIELDS_FIELD
+          @drawYAxisControls(globals.configs.fieldSelection,
+            data.normalFields.slice(1), true, 'Fields', @configs.displayField,
+            @yAxisRadioHandler)
         @drawToolControls(false, false, [@ANALYSISTYPE_MEAN_ERROR])
         @drawClippingControls()
         @drawSaveControls()

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -214,7 +214,10 @@ $ ->
       ###
       drawControls: ->
         super()
-        @drawGroupControls(data.textFields)
+        # Remove group by number fields, only for pie chart
+        groups = $.extend(true, [], data.textFields)
+        groups.splice(2, 1)
+        @drawGroupControls(groups)
         @drawXAxisControls()
         @drawYAxisControls(globals.configs.fieldSelection,
           data.normalFields.slice(1), false)

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -216,7 +216,7 @@ $ ->
         super()
         # Remove group by number fields, only for pie chart
         groups = $.extend(true, [], data.textFields)
-        groups.splice(2, 1)
+        groups.splice(data.NUMBER_FIELDS_FIELD - 1, 1)
         @drawGroupControls(groups)
         @drawXAxisControls()
         @drawYAxisControls(globals.configs.fieldSelection,

--- a/app/assets/javascripts/visualizations/highvis/summary.coffee
+++ b/app/assets/javascripts/visualizations/highvis/summary.coffee
@@ -105,6 +105,9 @@ $ ->
 
       drawControls: ->
         super()
+        # Remove group by number fields, only for pie chart
+        groups = $.extend(true, [], data.textFields)
+        groups.splice(2, 1)
         @drawGroupControls(data.textFields)
         @drawYAxisControls(globals.configs.fieldSelection,
           data.normalFields.slice(1), true, 'Fields', @configs.displayField,

--- a/app/assets/javascripts/visualizations/highvis/summary.coffee
+++ b/app/assets/javascripts/visualizations/highvis/summary.coffee
@@ -107,8 +107,8 @@ $ ->
         super()
         # Remove group by number fields, only for pie chart
         groups = $.extend(true, [], data.textFields)
-        groups.splice(2, 1)
-        @drawGroupControls(data.textFields)
+        groups.splice(data.NUMBER_FIELDS_FIELD - 1, 1)
+        @drawGroupControls(groups)
         @drawYAxisControls(globals.configs.fieldSelection,
           data.normalFields.slice(1), true, 'Fields', @configs.displayField,
           @yAxisRadioHandler)

--- a/app/assets/javascripts/visualizations/highvis/table.coffee
+++ b/app/assets/javascripts/visualizations/highvis/table.coffee
@@ -217,7 +217,10 @@ $ ->
 
       drawControls: ->
         super()
-        @drawGroupControls(data.textFields)
+        # Remove group by number fields, only for pie chart
+        groups = $.extend(true, [], data.textFields)
+        groups.splice(2, 1)
+        @drawGroupControls(groups)
         fields = (i for f, i in data.fields when i isnt data.COMBINED_FIELD)
         @drawYAxisControls(@configs.tableFields,
           (i for f, i in data.fields when i isnt data.COMBINED_FIELD),

--- a/app/assets/javascripts/visualizations/highvis/table.coffee
+++ b/app/assets/javascripts/visualizations/highvis/table.coffee
@@ -219,7 +219,7 @@ $ ->
         super()
         # Remove group by number fields, only for pie chart
         groups = $.extend(true, [], data.textFields)
-        groups.splice(2, 1)
+        groups.splice(data.NUMBER_FIELDS_FIELD - 1, 1)
         @drawGroupControls(groups)
         fields = (i for f, i in data.fields when i isnt data.COMBINED_FIELD and i isnt data.NUMBER_FIELDS_FIELD)
         @drawYAxisControls(@configs.tableFields,

--- a/app/assets/javascripts/visualizations/highvis/table.coffee
+++ b/app/assets/javascripts/visualizations/highvis/table.coffee
@@ -35,7 +35,7 @@ $ ->
         super(@canvas)
         @TOOLBAR_HEIGHT_OFFSET = 70
 
-        fieldList = (i for f, i in data.fields when i isnt data.COMBINED_FIELD)
+        fieldList = (i for f, i in data.fields when i isnt data.COMBINED_FIELD and i isnt data.NUMBER_FIELDS_FIELD)
         rows = Math.round( $(window).width() / 180 )
         @configs.tableFields ?= fieldList[0..rows]
 
@@ -221,9 +221,9 @@ $ ->
         groups = $.extend(true, [], data.textFields)
         groups.splice(2, 1)
         @drawGroupControls(groups)
-        fields = (i for f, i in data.fields when i isnt data.COMBINED_FIELD)
+        fields = (i for f, i in data.fields when i isnt data.COMBINED_FIELD and i isnt data.NUMBER_FIELDS_FIELD)
         @drawYAxisControls(@configs.tableFields,
-          (i for f, i in data.fields when i isnt data.COMBINED_FIELD),
+          (i for f, i in data.fields when i isnt data.COMBINED_FIELD and i isnt data.NUMBER_FIELDS_FIELD),
           false, 'Visible Fields')
         @drawClippingControls()
         @drawSaveControls()

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -239,6 +239,8 @@ class VisualizationsController < ApplicationController
     data_fields.push(typeID: TEXT_TYPE, unitName: 'String', fieldID: -1, fieldName: 'Data Set Name (id)')
     # create special grouping field for all datasets
     data_fields.push(typeID: TEXT_TYPE, unitName: 'String', fieldID: -1, fieldName: 'Combined Data Sets')
+    # create special grouping field for number fields
+    data_fields.push(typeID: TEXT_TYPE, unitName: 'String', fieldID: -1, fieldName: 'Number Fields')
     lat = ''
     # push real fields to temp variable
     @project.fields.sort_by(&:index).each do |field|
@@ -264,6 +266,7 @@ class VisualizationsController < ApplicationController
         arr = []
         arr.push index + 1
         arr.push "#{dataset.title}(#{dataset.id})"
+        arr.push 'All'
         arr.push 'All'
 
         data_fields.slice(arr.length, data_fields.length).each do |field|


### PR DESCRIPTION
Project has 3 number fields -> Wins, losses, and Ties
This pull request will allow you to make a pie chart to compare these 3 fields. 

It works by adding a new group by option just for Pie chart. While grouping by number fields, each slice of the pie represents a seperate number field instead of a portion of a single number field.
