### PR TITLE
Canceling print no longer breaks vis

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -542,6 +542,16 @@ $ ->
 
         $('#print-vis-btn').click =>
           @chart.print()
+          # Callback to detect when print controls have been closed
+          callback = ->
+            # After print controls are closed, resize vis (issue #2291)
+            globals.configs.ctrlsOpen = true
+            $(window).resize()
+          setTimeout callback, 1000
+          # Resize again; otherwise, the vis is half-sized.
+          # Doesn't work withut putting it in another callback; I dont know why
+          call2 = -> $(window).resize()
+          setTimeout call2, 1000
 
         # Initialize and track the status of this control panel
         globals.configs.saveOpen ?= false


### PR DESCRIPTION
This fixes issue #2291. The root of the problem is an [error in highcharts](https://github.com/highcharts/highcharts/issues/1093) that has gone unfixed for years. The workaround I made was to manually resize the page after the print dialog closes.