### PR TITLE
fixed bug #2358 bad table select highlight color

### DIFF
--- a/app/assets/stylesheets/visualizations.css.scss
+++ b/app/assets/stylesheets/visualizations.css.scss
@@ -538,6 +538,10 @@ ul#sopt_menu {
   }
 }
 
+tr.ui-widget-content.jqgrow.ui-row-ltr.ui-state-highlight {
+  border: 2px solid #263960;
+}
+
 body[data-page-name='visualizations/displayVis'] .visualizations-controller,
 body[data-page-name='visualizations/show'] .visualizations-controller {
   .ui-accordion-header {


### PR DESCRIPTION
#2358
The bug here was that when you selected a row of the table, a border was created around the row in a really ugly light yellow color.  The border was around all of the row/column lines in that row except for the top line.  I overrode the bad table selection highlighting by overriding the problem class with a class that adds an even, dark blue border just around the row itself.

Since there weren't any specific requests for what the correct table select should look like, and I couldn't find any similar outline selection anywhere else on the website to match it with, I just kind of used my judgement as to what looked good.  It's definitely better than the yellow, but if you need me to change the outline color, thickness, background-color, etc just let me know and I can update that too.