### PR TITLE
Large visualizations are resized before printing so they are not cut off

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -541,8 +541,9 @@ $ ->
             type: "image/svg+xml"
 
         $('#print-vis-btn').click =>
-        	# if (@chart.chartWidth > 700) 
-         #    @chart.setSize(700, @chart.chartHeight, false)
+          # Resize chart if it is too big to print
+        	if (@chart.chartWidth > 700) 
+            @chart.setSize(700, @chart.chartHeight, false)
           @chart.print()
           # Callback to detect when print controls have been closed
           callback = ->

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -541,6 +541,8 @@ $ ->
             type: "image/svg+xml"
 
         $('#print-vis-btn').click =>
+        	# if (@chart.chartWidth > 700) 
+         #    @chart.setSize(700, @chart.chartHeight, false)
           @chart.print()
           # Callback to detect when print controls have been closed
           callback = ->
@@ -549,7 +551,7 @@ $ ->
             $(window).resize()
           setTimeout callback, 1000
           # Resize again; otherwise, the vis is half-sized.
-          # Doesn't work withut putting it in another callback; I dont know why
+          # Doesn't work without putting it in another callback; I dont know why
           call2 = -> $(window).resize()
           setTimeout call2, 1000
 


### PR DESCRIPTION
This fixes issue #2290. The fix was to simply resize the vis to 700 if it is larger than 700 (700 being the approximate width of the printed page).