### PR TITLE
User page now shows correct error message when trying to delete a missing item.

### DIFF
--- a/app/assets/javascripts/users/show.js.coffee
+++ b/app/assets/javascripts/users/show.js.coffee
@@ -7,8 +7,7 @@ $ ->
         query.closest('tr').after('<tr></tr>').hide()
 
     $(document).ajaxError (event, xhr, settings, error) ->
-      e = JSON.parse xhr.responseText
-      quickFlash(e, 'error')
+      quickFlash("Sorry, but the file you are looking for does not exist.", 'error')
 
     navList = []
 

--- a/app/assets/javascripts/users/show.js.coffee
+++ b/app/assets/javascripts/users/show.js.coffee
@@ -7,7 +7,8 @@ $ ->
         query.closest('tr').after('<tr></tr>').hide()
 
     $(document).ajaxError (event, xhr, settings, error) ->
-      quickFlash("Sorry, but the file you are looking for does not exist.", 'error')
+      e = JSON.parse xhr.responseText
+      quickFlash(e["error"], 'error')
 
     navList = []
 

--- a/app/controllers/data_sets_controller.rb
+++ b/app/controllers/data_sets_controller.rb
@@ -125,7 +125,7 @@ class DataSetsController < ApplicationController
       @data_set = DataSet.find(params[:id])
     rescue ActiveRecord::RecordNotFound
       respond_to do |format|
-        format.json { render json: { error: "Data set not found." }, status: :not_found }
+        format.json { render json: { error: 'Data set not found.' }, status: :not_found }
       end
       return
     end

--- a/app/controllers/data_sets_controller.rb
+++ b/app/controllers/data_sets_controller.rb
@@ -121,7 +121,14 @@ class DataSetsController < ApplicationController
   # DELETE /data_sets/1
   # DELETE /data_sets/1.json
   def destroy
-    @data_set = DataSet.find(params[:id])
+    begin
+      @data_set = DataSet.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      respond_to do |format|
+        format.json { render json: { error: "Data set not found." }, status: :not_found }
+      end
+      return
+    end
     @project  = @data_set.project
     @errors = []
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -171,7 +171,14 @@ class ProjectsController < ApplicationController
   # DELETE /projects/1
   # DELETE /projects/1.json
   def destroy
-    @project = Project.find(params[:id])
+    begin
+      @project = Project.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      respond_to do |format|
+        format.json { render json: { error: "Project not found." }, status: :not_found }
+      end
+      return
+    end
 
     unless can_delete?(@project)
       respond_to do |format|

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -175,7 +175,7 @@ class ProjectsController < ApplicationController
       @project = Project.find(params[:id])
     rescue ActiveRecord::RecordNotFound
       respond_to do |format|
-        format.json { render json: { error: "Project not found." }, status: :not_found }
+        format.json { render json: { error: 'Project not found.' }, status: :not_found }
       end
       return
     end

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -190,7 +190,7 @@ class VisualizationsController < ApplicationController
       @visualization = Visualization.find(params[:id])
     rescue ActiveRecord::RecordNotFound
       respond_to do |format|
-        format.json { render json: { error: "Visualization not found." }, status: :not_found }
+        format.json { render json: { error: 'Visualization not found.' }, status: :not_found }
       end
       return
     end

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -186,7 +186,14 @@ class VisualizationsController < ApplicationController
   # DELETE /visualizations/1
   # DELETE /visualizations/1.json
   def destroy
-    @visualization = Visualization.find(params[:id])
+    begin
+      @visualization = Visualization.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      respond_to do |format|
+        format.json { render json: { error: "Visualization not found." }, status: :not_found }
+      end
+      return
+    end
 
     if can_delete?(@visualization)
 


### PR DESCRIPTION
This fixes issue #2239. The cause was the line of code `e = JSON.parse xhr.responseText`. The problem was that xhr.responeText returns some sort of stack trace, which is not JSON. So when JSON.parse tries to parse it, it throws a syntax error.
I have now fixed the original database calls, which were throwing uncaught RecordNotFound exceptions. They are now handled and pass an appropriate error message to the user page.