### PR TITLE
Filter labels for time stamps are now formatted correctly.

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/filters.coffee
+++ b/app/assets/javascripts/visualizations/highvis/filters.coffee
@@ -41,13 +41,12 @@ $ ->
     window.addFilter = (f) ->
       f.fieldName = fieldTitle(data.fields[f.field])
       f.opName    = globals.filterNames[f.op]
-
       formatter =
         if f.field is data.timeFields[0] then globals.dateFormatter
         else data.precisionFilter
 
       if f.value?
-        f.dispValue = f.value
+        f.dispValue = formatter(f.value)
       else
         delimiter = ', '
         switch f.op
@@ -62,9 +61,9 @@ $ ->
             closer = ')'
 
         f.dispValue = opener
-        if f.lvalue? then f.dispValue += data.precisionFilter(f.lvalue)
+        if f.lvalue? then f.dispValue += formatter(f.lvalue)
         f.dispValue += delimiter
-        if f.uvalue? then f.dispValue += data.precisionFilter(f.uvalue)
+        if f.uvalue? then f.dispValue += formatter(f.uvalue)
         f.dispValue += closer
 
       filterBox = HandlebarsTemplates[hbVis('vis-filter')](f)

--- a/test/integration/filter_timestamp_label_test.rb
+++ b/test/integration/filter_timestamp_label_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require_relative 'base_integration_test'
+
+class FilterTimestampLabelTest < IntegrationTest
+  self.use_transactional_fixtures = false
+
+  setup do
+    @project_id = projects(:timeline_vis_disable).id
+    @dataset_1_id = data_sets(:timeline_vis_disable_dset_with_time).id
+    @dataset_2_id = data_sets(:timeline_vis_disable_dset_no_time).id
+    @dataset_3_id = data_sets(:timeline_vis_disable_dset_some_time).id
+  end
+
+  test 'filter label for timestamp should show date' do
+    visit "/projects/#{@project_id}/data_sets/#{@dataset_1_id},#{@dataset_2_id},#{@dataset_3_id}"
+    current_window.resize_to 1000, 1000
+    click_on 'Timeline'
+    find("#clipping-ctrls").click
+    find(".bootstrap-switch-label").click
+    click_on "Set Current Filters"
+    assert page.has_content?('Dec'), 'filter label for timestamps should be formatted'
+  end
+end

--- a/test/integration/filter_timestamp_label_test.rb
+++ b/test/integration/filter_timestamp_label_test.rb
@@ -15,9 +15,9 @@ class FilterTimestampLabelTest < IntegrationTest
     visit "/projects/#{@project_id}/data_sets/#{@dataset_1_id},#{@dataset_2_id},#{@dataset_3_id}"
     current_window.resize_to 1000, 1000
     click_on 'Timeline'
-    find("#clipping-ctrls").click
-    find(".bootstrap-switch-label").click
-    click_on "Set Current Filters"
+    find('#clipping-ctrls').click
+    find('.bootstrap-switch-label').click
+    click_on 'Set Current Filters'
     assert page.has_content?('Dec'), 'filter label for timestamps should be formatted'
   end
 end


### PR DESCRIPTION
Fixes issue #2365. In filters.coffee, the formatter was set but never used. I simply changed it so that the formatter variable was actually used. Also added a test to make sure it stays fixed.