### PR TITLE
Temporary fix for uploading data from CSV or API

### DIFF
--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -115,11 +115,11 @@ class DataSet < ActiveRecord::Base
     if formula_fields.nil?
       formula_fields = project.formula_fields
     end
-    
+
     if formula_fields.length == 0
       return
     end
-    
+
     if fields.nil?
       fields = project.fields
     end
@@ -133,7 +133,13 @@ class DataSet < ActiveRecord::Base
       key = x.id.to_s
       beaker_arr = case x.field_type
                    when 1
-                     arr = data.map { |y| DateTime.parse(y[key]) rescue nil }
+                     arr = data.map do |y|
+                       begin
+                         DateTime.parse(y[key])
+                       rescue
+                         nil
+                       end
+                     end
                      Beaker::ArrayType.new(arr, :timestamp, 0)
                    when 2
                      arr = data.map { |y| y[key].nil? or y[key] == '' ? nil : y[key].to_f }

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -133,7 +133,7 @@ class DataSet < ActiveRecord::Base
       key = x.id.to_s
       beaker_arr = case x.field_type
                    when 1
-                     arr = data.map { |y| DateTime.parse(y[key]) }
+                     arr = data.map { |y| DateTime.parse(y[key]) rescue nil }
                      Beaker::ArrayType.new(arr, :timestamp, 0)
                    when 2
                      arr = data.map { |y| y[key].nil? or y[key] == '' ? nil : y[key].to_f }

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -115,7 +115,11 @@ class DataSet < ActiveRecord::Base
     if formula_fields.nil?
       formula_fields = project.formula_fields
     end
-
+    
+    if formula_fields.length == 0
+      return
+    end
+    
     if fields.nil?
       fields = project.fields
     end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,8 @@ Rsense::Application.configure do
 
   # info log level leaks password reset tokens which is a BIG SECURITY HOLE!
   # anyone who got access to our logs, they could steal tokens and reset user's passwords
-  config.log_level = :warn
+  # Dev note: We're leaving it at "info" level for now. Will decide how to proceed later.
+  config.log_level = :info
 
   # Prepend all log lines with the following tags
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
The Formula Fields code is broken - it currently fails when a user tries to upload Timestamp data from an API or a CSV. For whatever reason, the portion of code that breaks runs whether or not the user actually has any formula fields set up.

The temporary fix is to abort the faulty function if there are no formula fields present. This will allow us to continue using APIs for now, but a more robust fix is needed ASAP.