### PR TITLE
Newer versions of ImageMagick now work with our development environment.

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/savedVis.coffee
+++ b/app/assets/javascripts/visualizations/highvis/savedVis.coffee
@@ -50,10 +50,11 @@ $ ->
         backdrop: 'static'
         keyboard: 'false'
 
-      # Strip all font selection away from svg (except for "sans-serif") so that newer versions of ImageMagick work.
-      # Our site uses the default sans-serif font anyway.
+      # New versions of ImageMagick have issue with the way Highcharts puts quotes 
+      # around the first two fonts, so just remove those fonts from the style attribute.
+      # Our site uses arial anyway.
       svg = if globals.curVis.chart?
-        globals.curVis.chart.getSVG().replace("'lucida grande', 'lucida sans unicode', arial, helvetica, ", "")
+        globals.curVis.chart.getSVG().replace("'lucida grande', 'lucida sans unicode', ", "")
       else
         undefined
 

--- a/app/assets/javascripts/visualizations/highvis/savedVis.coffee
+++ b/app/assets/javascripts/visualizations/highvis/savedVis.coffee
@@ -50,7 +50,7 @@ $ ->
         backdrop: 'static'
         keyboard: 'false'
 
-      # New versions of ImageMagick have issue with the way Highcharts puts quotes 
+      # New versions of ImageMagick have issue with the way Highcharts puts quotes
       # around the first two fonts, so just remove those fonts from the style attribute.
       # Our site uses arial anyway.
       svg = if globals.curVis.chart?

--- a/app/assets/javascripts/visualizations/highvis/savedVis.coffee
+++ b/app/assets/javascripts/visualizations/highvis/savedVis.coffee
@@ -50,8 +50,10 @@ $ ->
         backdrop: 'static'
         keyboard: 'false'
 
+      # Strip all font selection away from svg (except for "sans-serif") so that newer versions of ImageMagick work.
+      # Our site uses the default sans-serif font anyway.
       svg = if globals.curVis.chart?
-        globals.curVis.chart.getSVG()
+        globals.curVis.chart.getSVG().replace("'lucida grande', 'lucida sans unicode', arial, helvetica, ", "")
       else
         undefined
 


### PR DESCRIPTION
Newer versions of ImageMagick had issues with the way that Highcharts exports SVGs of charts. Specifically, it didn't like that the first few fonts in the style attribute had single quotes around them:

`style="font-family:'lucida grande', 'lucida sans unicode', arial, helvetica, sans-serif;font-size:12px;"`

To fix it, I just removed those two fonts from the list:

`style="font-family:arial, helvetica, sans-serif;font-size:12px;"`

This doesn't change the way the site works, because our site just uses Arial anyway.