### PR TITLE
Period feature now correctly removed when project has no timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ node_modules/
 
 # visual studio code
 .vscode
+
+# some linters want coffeelint files to be named a specific way.
+coffeelint.json

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -149,6 +149,9 @@ $ ->
         # Remove group by number fields, only for pie chart
         groups = $.extend(true, [], data.textFields)
         groups.splice(data.NUMBER_FIELDS_FIELD - 1, 1)
+        # Remove Group By Time Period if there is no time data
+        if data.hasTimeData is false or data.timeType == data.GEO_TIME
+          groups.splice(data.TIME_PERIOD_FIELD - 2, 1)
         @drawGroupControls(groups)
         @drawYAxisControls(globals.configs.fieldSelection,
           data.normalFields.slice(1), false)

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -571,7 +571,12 @@ $ ->
         inctx = {}
 
         # Add Period to Base Tools
-        inctx.period = HandlebarsTemplates[hbCtrl('period')]
+        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+          inctx.period = HandlebarsTemplates[hbCtrl('period')]
+        else
+          # Safeguard, in case the default vis has time data but the current dataset does not.
+          globals.configs.isPeriod = false
+          globals.configs.periodMode = 'off'
         
         # Populate sort fields
         if sortBy
@@ -661,7 +666,8 @@ $ ->
           @start()
       
         # Set the correct options for period:
-        $('#period-list').val(globals.configs.periodMode)
+        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+          $('#period-list').val(globals.configs.periodMode)
 
         $('#period-list').change =>
           globals.configs.periodMode = $('#period-list').val()

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -59,6 +59,11 @@ $ ->
       start: ->
         $('#' + @canvas).show()
         toolScroll = $('#vis-ctrls').scrollTop()
+        #Protect against edge case where the default vis uses the period mode but this dataset doesn't have time data:
+        if globals.configs.groupById == data.TIME_PERIOD_FIELD and 
+        ( data.hasTimeData is false or data.timeType == data.GEO_TIME )
+          data.setGroupIndex(data.COMBINED_FIELD)
+          globals.configs.groupById = data.COMBINED_FIELD
         @drawControls()
         @update()
         $('#vis-ctrls').scrollTop(toolScroll)

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -576,12 +576,8 @@ $ ->
         inctx = {}
 
         # Add Period to Base Tools
-        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+        if data.hasTimeData and data.timeType != data.GEO_TIME
           inctx.period = HandlebarsTemplates[hbCtrl('period')]
-        else
-          # Safeguard, in case the default vis has time data but the current dataset does not.
-          globals.configs.isPeriod = false
-          globals.configs.periodMode = 'off'
         
         # Populate sort fields
         if sortBy
@@ -671,8 +667,7 @@ $ ->
           @start()
       
         # Set the correct options for period:
-        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
-          $('#period-list').val(globals.configs.periodMode)
+        $('#period-list').val(globals.configs.periodMode)
 
         $('#period-list').change =>
           globals.configs.periodMode = $('#period-list').val()

--- a/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
+++ b/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
@@ -359,8 +359,11 @@ $ ->
         # Look through all timestamps to find the different time periods to use for groups
         for point in data.dataPoints
           timestamp = point[timestampIndex]
-          period = globals.getCurrentPeriod(new Date(timestamp))
-          point[data.TIME_PERIOD_FIELD] = period
+          if timestamp is null
+            point[data.TIME_PERIOD_FIELD] = "No Time Data"
+          else
+            period = globals.getCurrentPeriod(new Date(timestamp))
+            point[data.TIME_PERIOD_FIELD] = period
 
       for dp in @dataPoints
         if dp[gIndex] isnt null

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -275,12 +275,8 @@ $ ->
         inctx =
           binSize: @configs.binSize
           
-        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+        if data.hasTimeData and data.timeType != data.GEO_TIME
           inctx.period = HandlebarsTemplates[hbCtrl('period')]
-        else
-          # Safeguard, in case the default vis has time data but the current dataset does not.
-          globals.configs.isPeriod = false
-          globals.configs.periodMode = 'off'
 
         outctx =
           id: 'tools-ctrls'
@@ -291,8 +287,7 @@ $ ->
         $('#vis-ctrls').append(tools)
         
         # Set the correct options for period:
-        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
-          $('#period-list').val(globals.configs.periodMode)
+        $('#period-list').val(globals.configs.periodMode)
 
         $('#period-list').change =>
           globals.configs.periodMode = $('#period-list').val()

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -274,7 +274,13 @@ $ ->
       drawToolControls: ->
         inctx =
           binSize: @configs.binSize
-          period: HandlebarsTemplates[hbCtrl('period')]
+          
+        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+          inctx.period = HandlebarsTemplates[hbCtrl('period')]
+        else
+          # Safeguard, in case the default vis has time data but the current dataset does not.
+          globals.configs.isPeriod = false
+          globals.configs.periodMode = 'off'
 
         outctx =
           id: 'tools-ctrls'
@@ -285,7 +291,8 @@ $ ->
         $('#vis-ctrls').append(tools)
         
         # Set the correct options for period:
-        $('#period-list').val(globals.configs.periodMode)
+        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+          $('#period-list').val(globals.configs.periodMode)
 
         $('#period-list').change =>
           globals.configs.periodMode = $('#period-list').val()

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -361,6 +361,9 @@ $ ->
         # Remove group by number fields, only for pie chart
         groups = $.extend(true, [], data.textFields)
         groups.splice(data.NUMBER_FIELDS_FIELD - 1, 1)
+        # Remove Group By Time Period if there is no time data
+        if data.hasTimeData is false or data.timeType == data.GEO_TIME
+          groups.splice(data.TIME_PERIOD_FIELD - 2, 1)
         @drawGroupControls(groups)
 
         handler = (selected, selFields) =>

--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -481,7 +481,13 @@ $ ->
               label: 'Marker Density'
             }
           ]
-          period: HandlebarsTemplates[hbCtrl('period')]
+
+        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+          inctx.period = HandlebarsTemplates[hbCtrl('period')]
+        else
+          # Safeguard, in case the default vis has time data but the current dataset does not.
+          globals.configs.isPeriod = false
+          globals.configs.periodMode = 'off'
 
         for i in data.normalFields
           inctx.heatmaps.push
@@ -498,7 +504,8 @@ $ ->
         $('#vis-ctrls').append(tools)
         
         # Set the correct options for period:
-        $('#period-list').val(globals.configs.periodMode)
+        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+          $('#period-list').val(globals.configs.periodMode)
 
         $('#period-list').change =>
           console.log('Period:')

--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -447,6 +447,9 @@ $ ->
         # Remove group by number fields
         groups = $.extend(true, [], data.textFields)
         groups.splice(data.NUMBER_FIELDS_FIELD - 1, 1)
+        # Remove Group By Time Period if there is no time data
+        if data.hasTimeData is false or data.timeType == data.GEO_TIME
+          groups.splice(data.TIME_PERIOD_FIELD - 2, 1)
         @drawGroupControls(groups, true)
         @drawToolControls()
         @drawClippingControls()

--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -485,12 +485,8 @@ $ ->
             }
           ]
 
-        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+        if data.hasTimeData and data.timeType != data.GEO_TIME
           inctx.period = HandlebarsTemplates[hbCtrl('period')]
-        else
-          # Safeguard, in case the default vis has time data but the current dataset does not.
-          globals.configs.isPeriod = false
-          globals.configs.periodMode = 'off'
 
         for i in data.normalFields
           inctx.heatmaps.push
@@ -507,8 +503,7 @@ $ ->
         $('#vis-ctrls').append(tools)
         
         # Set the correct options for period:
-        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
-          $('#period-list').val(globals.configs.periodMode)
+        $('#period-list').val(globals.configs.periodMode)
 
         $('#period-list').change =>
           console.log('Period:')

--- a/app/assets/javascripts/visualizations/highvis/pie.coffee
+++ b/app/assets/javascripts/visualizations/highvis/pie.coffee
@@ -116,7 +116,11 @@ $ ->
 
       drawControls: ->
         super()
-        @drawGroupControls(data.textFields)
+        groups = $.extend(true, [], data.textFields)
+        # Remove Group By Time Period if there is no time data
+        if data.hasTimeData is false or data.timeType == data.GEO_TIME
+          groups.splice(data.TIME_PERIOD_FIELD - 1, 1)
+        @drawGroupControls(groups)
         if globals.configs.groupById != data.NUMBER_FIELDS_FIELD
           @drawYAxisControls(globals.configs.fieldSelection,
             data.normalFields.slice(1), true, 'Fields', @configs.displayField,

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -314,7 +314,8 @@ $ ->
             # fixes it by splitting the data into different series based on the range
             # the point falls in (ex fixed: http://i.imgur.com/NDIrq8i.png).
             datArray = new Array
-            if globals.configs.isPeriod is true
+            console.log(@isScatter)
+            if @isScatter is null and globals.configs.isPeriod is true and data.timeType is data.NORM_TIME
               currentPeriod = null
               for point in dat
                 newDate = new Date(point.x)

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -314,8 +314,7 @@ $ ->
             # fixes it by splitting the data into different series based on the range
             # the point falls in (ex fixed: http://i.imgur.com/NDIrq8i.png).
             datArray = new Array
-            console.log(@isScatter)
-            if @isScatter is null and globals.configs.isPeriod is true and data.timeType is data.NORM_TIME
+            if @isScatter is null and globals.configs.isPeriod is true and data.timeType == data.NORM_TIME
               currentPeriod = null
               for point in dat
                 newDate = new Date(point.x)
@@ -442,7 +441,13 @@ $ ->
           { mode: @LINES_MODE,         text: "Lines Only" }
           { mode: @SYMBOLS_MODE,       text: "Symbols Only" }
         ]
-        inctx.period = HandlebarsTemplates[hbCtrl('period')]
+
+        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+          inctx.period = HandlebarsTemplates[hbCtrl('period')]
+        else
+          # Safeguard, in case the default vis has time data but the current dataset does not.
+          globals.configs.isPeriod = false
+          globals.configs.periodMode = 'off'
 
         # Draw the Tool controls
         outctx = {}
@@ -454,7 +459,8 @@ $ ->
         $('#vis-ctrls').append tools
         
         # Set the correct options for period:
-        $('#period-list').val(globals.configs.periodMode)
+        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+          $('#period-list').val(globals.configs.periodMode)
 
         $('#period-list').change =>
           globals.configs.periodMode = $('#period-list').val()

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -440,12 +440,9 @@ $ ->
           { mode: @SYMBOLS_MODE,       text: "Symbols Only" }
         ]
 
-        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+        if data.hasTimeData and data.timeType != data.GEO_TIME
           inctx.period = HandlebarsTemplates[hbCtrl('period')]
-        else
-          # Safeguard, in case the default vis has time data but the current dataset does not.
-          globals.configs.isPeriod = false
-          globals.configs.periodMode = 'off'
+
 
         # Draw the Tool controls
         outctx = {}
@@ -457,8 +454,7 @@ $ ->
         $('#vis-ctrls').append tools
         
         # Set the correct options for period:
-        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
-          $('#period-list').val(globals.configs.periodMode)
+        $('#period-list').val(globals.configs.periodMode)
 
         $('#period-list').change =>
           globals.configs.periodMode = $('#period-list').val()

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -282,11 +282,6 @@ $ ->
               @configs.xBounds.max = Math.max(@configs.xBounds.max,
                 data.getMax(@configs.xAxis, gi, dp))
 
-              if (@timeMode isnt undefined) and (@timeMode is @GEO_TIME_MODE)
-                @configs.xBounds.min =
-                  (new Date(@configs.xBounds.min)).getUTCFullYear()
-                @configs.xBounds.max =
-                  (new Date(@configs.xBounds.max)).getUTCFullYear()
 
         # Calculate grid spacing for data reduction
         width = $('#' + @canvas).innerWidth()

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -220,6 +220,9 @@ $ ->
         # Remove group by number fields, only for pie chart
         groups = $.extend(true, [], data.textFields)
         groups.splice(data.NUMBER_FIELDS_FIELD - 1, 1)
+        # Remove Group By Time Period if there is no time data
+        if data.hasTimeData is false or data.timeType == data.GEO_TIME
+          groups.splice(data.TIME_PERIOD_FIELD - 2, 1)
         @drawGroupControls(groups)
         @drawXAxisControls()
         @drawYAxisControls(globals.configs.fieldSelection,

--- a/app/assets/javascripts/visualizations/highvis/summary.coffee
+++ b/app/assets/javascripts/visualizations/highvis/summary.coffee
@@ -108,7 +108,10 @@ $ ->
         super()
         # Remove group by number fields, only for pie chart
         groups = $.extend(true, [], data.textFields)
+        # Remove Group By Time Period if there is no time data
         groups.splice(data.NUMBER_FIELDS_FIELD - 1, 1)
+        if data.hasTimeData is false or data.timeType == data.GEO_TIME
+          groups.splice(data.TIME_PERIOD_FIELD - 2, 1)
         @drawGroupControls(groups)
         @drawYAxisControls(globals.configs.fieldSelection,
           data.normalFields.slice(1), true, 'Fields', @configs.displayField,

--- a/app/assets/javascripts/visualizations/highvis/table.coffee
+++ b/app/assets/javascripts/visualizations/highvis/table.coffee
@@ -235,7 +235,9 @@ $ ->
            i isnt data.NUMBER_FIELDS_FIELD and i isnt data.TIME_PERIOD_FIELD),
           false, 'Visible Fields')
         @drawClippingControls()
-        @drawToolControls(false, false, [], false)
+        # Period is currently the only Tool for table. Don't render Tool Controls if period is not available.'
+        if data.timeFields.length > 0 and data.timeType != data.GEO_TIME
+          @drawToolControls(false, false, [], false)
         @drawSaveControls()
 
       saveSort: =>

--- a/app/assets/javascripts/visualizations/highvis/table.coffee
+++ b/app/assets/javascripts/visualizations/highvis/table.coffee
@@ -227,6 +227,9 @@ $ ->
         # Remove group by number fields, only for pie chart
         groups = $.extend(true, [], data.textFields)
         groups.splice(data.NUMBER_FIELDS_FIELD - 1, 1)
+        # Remove Group By Time Period if there is no time data
+        if data.hasTimeData is false or data.timeType == data.GEO_TIME
+          groups.splice(data.TIME_PERIOD_FIELD - 2, 1)
         @drawGroupControls(groups)
         fields = (i for f, i in data.fields when i isnt data.COMBINED_FIELD and
                   i isnt data.NUMBER_FIELDS_FIELD and i isnt data.TIME_PERIOD_FIELD)

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -335,7 +335,8 @@ class VisualizationsController < ApplicationController
               fields: data_fields,           dataPoints: format_data,
               metadata: metadata,            relVis: rel_vis,
               allVis: all_vis,               defaultVis: default_vis,
-              precision: @project.precision, savedGlobals: @project.globals }
+              precision: @project.precision, savedGlobals: @project.globals,
+              hasTimeData: time_count != 0 }
 
     options = {}
 


### PR DESCRIPTION
Fixes #2388.

If a visualization has no time data, the period tool and period group-by option will both be removed. 
Fixed an error where the period feature would mess up the x-coordinates on the Scatter vis.
When grouping by Time Period: if some data points were missing timestamps, they will be put into the "No Time Data" group.