### PR TITLE
Histogram Density (show underlying points for each bar)

### DIFF
--- a/app/assets/javascripts/templates/visualizations/controls/base-tools.hbs
+++ b/app/assets/javascripts/templates/visualizations/controls/base-tools.hbs
@@ -19,11 +19,14 @@
   </div>
 {{/if}}
 {{{period}}}
-{{#if logYAxis}}
+{{#if barChart}}
   <div class="vis-ctrl-subblock">
     <h4 class="vis-ctrl-subtitle">Other</h4>
     <div>
       {{> visualizations/controls/_checkbox logYAxis}}
+    </div>
+    <div>
+      {{> visualizations/controls/_checkbox histogramDensity}}
     </div>
   </div>
 {{/if}}

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -36,6 +36,7 @@ $ ->
 
       start: ->
         @configs.analysisType ?= @ANALYSISTYPE_MEAN
+        globals.configs.histogramDensity ?= false
 
         # Default Sort
         fs = globals.configs.fieldSelection
@@ -57,13 +58,16 @@ $ ->
           tooltip:
             formatter: ->
               str  = "<div style='width:100%;text-align:center;"
-              str += "color:#{@series.color};margin-bottom:5px'> "
-              str += "#{@series.name}</div>"
+              if globals.configs.histogramDensity
+                str += "color:#{@series.data[@x].borderColor};margin-bottom:5px'> "
+              else
+                str += "color:#{@series.data[@x].color};margin-bottom:5px'> "
+              str += "#{@series.data[@x].name}</div>"
               str += "<table>"
-              str += "<tr><td>#{data.fields[globals.configs.fieldSelection[@x]].fieldName} "
+              str += "<tr><td>#{data.fields[globals.configs.fieldSelection[0]].fieldName} "
               str += "(#{self.analysisTypeNames[self.configs.analysisType]}):"
               str += "</td><td><strong>#{@y} \
-              #{fieldUnit(data.fields[globals.configs.fieldSelection[@x]], false)}</strong></td></tr>"
+              #{fieldUnit(data.fields[globals.configs.fieldSelection[0]], false)}</strong></td></tr>"
               str += "</table>"
             useHTML: true
           yAxis:
@@ -74,9 +78,12 @@ $ ->
               value: 0
              }]
           xAxis:
-            type: 'category'
+            #type: 'category'
+            labels:
+              enabled: true
           legend:
             enabled: $(window).width() > 700 && data.groups.length < 30
+            
 
       update: ->
         super()
@@ -99,50 +106,118 @@ $ ->
             sortable.push [k, v] for k, v of groupedData[@configs.sortField]
             sortable.sort (a,b) -> a[1] - b[1]
             Number k for [k, v] in sortable
-
-        # Draw the series
+            
+        # Draw the bars
+        datArray = []
+        xCoords = 0
         for gid in sortedGroupIDs when gid in data.groupSelection
-          options =
-            color: globals.getColor(gid)
-            name:  data.groups[gid] or data.noField()
+          for fid in data.normalFields when fid in fieldSelection
+            thisData = {
+              x: xCoords
+              y: groupedData[fid][gid]
+              name:  data.groups[gid] or data.noField()
+            }
+          
+          xCoords += 1
+          
+          if globals.configs.histogramDensity
+            thisData.color = 'rgba(255,255,255,0)'
+            thisData.borderColor = globals.getColor(gid)
+          else
+            thisData.color = globals.getColor(gid)
+          
+          datArray.push(thisData)
 
-          options.data = for fid in data.normalFields when fid in fieldSelection
-            [fieldTitle(data.fields[fid]), groupedData[fid][gid]]
-
-          # Do not label x-axis if there is just one group
-          if options.data.length == 1
-            options.data[0][0] = ' '
-
-          @chart.addSeries options, false
-
-          # Draw error bars if that analysis type is selected
-          if @configs.analysisType == @ANALYSISTYPE_MEAN_ERROR
-            errors =
-              type: 'errorbar'
-              name: "Error for #{data.groups[gid]}" or data.noField()
-
-            errors.data = for fid in data.normalFields when fid in fieldSelection
+        series = {
+          data: datArray
+          showInLegend: false
+          borderWidth: 4
+          states:
+            hover:
+              enabled: false
+        }
+        @chart.addSeries series, false
+          
+        # Draw error bars, if option is enabled
+        if @configs.analysisType == @ANALYSISTYPE_MEAN_ERROR
+          allErrors = []
+          xCoords = 0
+          for gid in sortedGroupIDs when gid in data.groupSelection
+            for fid in data.normalFields when fid in fieldSelection
               dp = globals.getData(true, globals.configs.activeFilters)
               barData = data.selector fid, gid, dp
               if barData.length == 1
-                []
+                thisError = {}
               else
                 mean = groupedData[fid][gid]
                 innerStd = barData.map((x) -> (x - mean) ** 2).reduce((x, y) -> x + y)
                 stdDev = Math.sqrt((1 / (barData.length - 1)) * innerStd)
                 if !globals.configs.logY
-                  [mean - stdDev, mean + stdDev]
+                  # [mean - stdDev, mean + stdDev]
+                  thisError = {
+                    name: "Error for #{data.groups[gid]}" or data.noField()
+                    x: xCoords
+                    low: mean - stdDev
+                    high: mean + stdDev
+                  }
                 else if mean > 0
-                  [mean, mean + stdDev]
+                  thisError = {
+                    name: "Error for #{data.groups[gid]}" or data.noField()
+                    x: xCoords
+                    low: mean
+                    high: mean + stdDev
+                  }
                 else
-                  []
+                  thisError = {}
+                  
+              xCoords += 1    
+              allErrors.push(thisError)
 
-            @chart.addSeries errors
+          series = {
+            type: 'errorbar'
+            data: allErrors
+          }
+          @chart.addSeries series
 
+        # Draw points for each bar, if the option is enabled.
+        # if globals.configs.histogramDensity
+          
+          
+        
         @chart.redraw()
 
+      # Build dummy legend series
       buildLegendSeries: ->
-        []
+        groupedData = {}
+        for f in data.normalFields
+          groupedData[f] = @getGroupedData(f)
+
+        # Sort the sort-by field
+        # The default sort is just the group order
+        # Otherwise, make sortable key-pairs and sort by the sortField array
+        sortedGroupIDs =
+          if @configs.sortField is @SORT_DEFAULT
+            i for n, i in data.groups when i in data.groupSelection
+          else
+            sortable = []
+            sortable.push [k, v] for k, v of groupedData[@configs.sortField]
+            sortable.sort (a,b) -> a[1] - b[1]
+            Number k for [k, v] in sortable
+            
+        for gid in sortedGroupIDs when gid in data.groupSelection
+          options =
+            # dummy series needs to be scatter, otherwise it pushes
+            # the other bars over.
+            type: 'scatter'
+            showInLegend: true
+            color: globals.getColor(gid)
+            data: []
+            name: data.groups[gid] or data.noField()
+            marker:
+              symbol: 'square'
+              radius: 6
+            
+          options
 
       drawControls: ->
         super()

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -658,7 +658,7 @@ $ ->
         else if $('#ckbx-lbl-log-y-axis').length
           $('#ckbx-lbl-log-y-axis')[0].MaterialCheckbox.uncheck()
           
-        if globals.configs.histogramDensity and $('#ckbx-lbl-hist-density').length
+        if @configs.histogramDensity and $('#ckbx-lbl-hist-density').length
           $('#ckbx-lbl-hist-density')[0].MaterialCheckbox.check()
         else if $('#ckbx-lbl-hist-density').length
           $('#ckbx-lbl-hist-density')[0].MaterialCheckbox.uncheck()
@@ -676,7 +676,7 @@ $ ->
           @start()
           
         $('#ckbx-hist-density').click () =>
-          globals.configs.histogramDensity = not globals.configs.histogramDensity
+          @configs.histogramDensity = not @configs.histogramDensity
           @delayedUpdate()
           
         # Set the correct options for period:

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -677,7 +677,7 @@ $ ->
           
         $('#ckbx-hist-density').click () =>
           globals.configs.histogramDensity = not globals.configs.histogramDensity
-          @start()
+          @delayedUpdate()
           
         # Set the correct options for period:
         $('#period-list').val(globals.configs.periodMode)

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -572,7 +572,7 @@ $ ->
       Draw tool controls (Analysis Type, Log Y Axis, etc.) for Pie Chart and
       Bar Charts
       ###
-      drawToolControls: (sortBy = false, logYAxis = false, analysisTypeExcludes = [], drawAnalysisTypes = true) ->
+      drawToolControls: (sortBy = false, barChart = false, analysisTypeExcludes = [], drawAnalysisTypes = true) ->
         inctx = {}
 
         # Add Period to Base Tools
@@ -615,13 +615,17 @@ $ ->
                 name:  'analysis-type'
                 label:  @analysisTypeNames[i]
 
-        # Logarithmic Y Axis
-        if logYAxis
-          id = 'log-y-axis'
+        # Bar-specific tools
+        if barChart
+          inctx.barChart = true
           inctx.logYAxis =
-            id:    id
+            id:    'log-y-axis'
             logId: 'logarithmic-y-axis'
             label: 'Logarithmic Y Axis'
+          inctx.histogramDensity =
+            id:    'hist-density'
+            logId: 'histogram-density'
+            label: 'Histogram Density'
 
         outctx =
           id: 'tools-ctrls'
@@ -653,6 +657,11 @@ $ ->
           $('#ckbx-lbl-log-y-axis')[0].MaterialCheckbox.check()
         else if $('#ckbx-lbl-log-y-axis').length
           $('#ckbx-lbl-log-y-axis')[0].MaterialCheckbox.uncheck()
+          
+        if globals.configs.histogramDensity and $('#ckbx-lbl-hist-density').length
+          $('#ckbx-lbl-hist-density')[0].MaterialCheckbox.check()
+        else if $('#ckbx-lbl-hist-density').length
+          $('#ckbx-lbl-hist-density')[0].MaterialCheckbox.uncheck()
 
         $('#sort-by').change (e) =>
           @configs.sortField = Number(e.target.value)
@@ -665,7 +674,11 @@ $ ->
         $('#ckbx-log-y-axis').click (e) =>
           globals.configs.logY = !globals.configs.logY
           @start()
-      
+          
+        $('#ckbx-hist-density').click () =>
+          globals.configs.histogramDensity = not globals.configs.histogramDensity
+          @start()
+          
         # Set the correct options for period:
         $('#period-list').val(globals.configs.periodMode)
 


### PR DESCRIPTION
For feature request #2399.
In order to implement this feature, basically all of bar.coffee had to be rewritten. Before, it utilized Highcharts' 'category' feature, in which bars are automatically grouped together based on a label. However, this way of doing things is completely incompatible with being able to draw points on top of the bars, as the points would just push the bars around. In addition, the bars used to be added each as their own series. That also causes the bars to be moved around in a way that cannot be tracked/controlled.

Now, bars are drawn to a specific x-coordinate, and all bars are part of a single series. This allows for the scatterplot points to be drawn at those same x-coordinates.

Using 'category' was prettier and easier, but rewriting the file had to be done to support this feature. All other functionality is identical, except for the spacing on the bars when drawn is a bit different. That can be easily changed at will.