### PR TITLE
"Filters:" No longer appears at the top of the vis every other time the vis selection changes

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
+++ b/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
@@ -34,6 +34,7 @@ $ ->
     globals.configs ?= {}
     globals.clippingVises = ['map', 'timeline', 'scatter', 'table']
     globals.configs.activeFilters ?= []
+    globals.configs.clippingMode ?= false
 
     globals.configs.isPeriod ?= false # Controls how series are constructed in update().
     globals.configs.periodMode ?= 'off' # Changes when a period option is selected.


### PR DESCRIPTION
For #2403.
A single line was deleted a while back, which caused this bug but somehow didn't break filtering completely.