### PR TITLE
Fixed Scatter plot zooming crash by limiting zoom level.

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -161,10 +161,12 @@ $ ->
             type: 'linear'
             gridLineWidth: 1
             minorTickInterval: 'auto'
+            minRange: 1e-10
             }]
           yAxis:
             startOnTick: false
             endOnTick: false
+            minRange: 1e-10
             type: if globals.configs.logY then 'logarithmic' else 'linear'
             events:
               afterSetExtremes: (e) =>


### PR DESCRIPTION
For #2364.
All I had to do was use Highcharts' [minRange](http://api.highcharts.com/highcharts#xAxis.minRange) option to limit the minimum range to 1e-10. If we wanted to limit the zoom based instead on the range between points, that can be done mathematically. But this is good for now.