### PR TITLE
Users can no longer inject client-side code into the website.

### DIFF
--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -45,11 +45,6 @@ class DataSet < ActiveRecord::Base
           data_row.delete key
         end
       end
-      # data_row.each do |key, value|
-      #   if value.is_a? String
-      #     data_row[key] = strip_tags(value)
-      #   end
-      # end
     end
   end
 

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -31,16 +31,25 @@ class DataSet < ActiveRecord::Base
   end
 
   def sanitize_data_set
-    self.title = sanitize title, tags: %w()
-
-    # replace numeric hash keys with string hash keys
+    self.title = strip_tags(title)
+    
     data.each do |data_row|
       data_row.keys.each do |key|
+        # Remove any and all HTML tags
+        if data_row[key].is_a? String
+          data_row[key] = strip_tags(data_row[key])
+        end
+        # replace numeric hash keys with string hash keys
         unless key.is_a? String
           data_row[key.to_s] = data_row[key]
           data_row.delete key
         end
       end
+      # data_row.each do |key, value|
+      #   if value.is_a? String
+      #     data_row[key] = strip_tags(value)
+      #   end
+      # end
     end
   end
 
@@ -190,6 +199,8 @@ class DataSet < ActiveRecord::Base
                  # if anything breaks, just return nil
                  nil
                end
+        # Strip HTML from result
+        eval = strip_tags(eval) if eval.is_a? String
         # dump this value into the array
         new_field.value[idx] = eval
         curr_env.add x.refname, new_field

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -32,7 +32,7 @@ class DataSet < ActiveRecord::Base
 
   def sanitize_data_set
     self.title = strip_tags(title)
-    
+
     data.each do |data_row|
       data_row.keys.each do |key|
         # Remove any and all HTML tags

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -116,7 +116,12 @@ class Field < ActiveRecord::Base
     # Strip HTML from input
     self.name = strip_tags(name)
     self.unit = strip_tags(unit)
-    self.restrictions = strip_tags(restrictions)
+    self.restrictions = strip_tags(restrictions) if restrictions.is_a? String
+    if restrictions.is_a? Array
+      restrictions.each_with_index do |v, i|
+        restrictions[i] = strip_tags(v) if restrictions[i].is_a? String
+      end
+    end
   end
 
   def validate_values

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -1,11 +1,18 @@
 include ApplicationHelper
 class Field < ActiveRecord::Base
+  include ActionView::Helpers::SanitizeHelper
+
   after_initialize :default_values
+
+  before_validation :sanitize_html
   before_validation :trim_restrictions
   before_validation :choose_refname
+
   validates_presence_of :project_id, :field_type, :name
+
   validates_uniqueness_of :name, scope: :project_id, case_sensitive: false
   validates_uniqueness_of :refname, scope: :project_id, case_sensitive: false
+
   validate :validate_values
   validate :unique_name
 
@@ -103,6 +110,13 @@ class Field < ActiveRecord::Base
     end
 
     self.refname = next_refname
+  end
+
+  def sanitize_html
+    # Strip HTML from input
+    self.name = strip_tags(name)
+    self.unit = strip_tags(unit)
+    self.restrictions = strip_tags(restrictions)
   end
 
   def validate_values

--- a/app/models/formula_field.rb
+++ b/app/models/formula_field.rb
@@ -1,10 +1,17 @@
 include ApplicationHelper
 class FormulaField < ActiveRecord::Base
+  include ActionView::Helpers::SanitizeHelper
+
   after_initialize :default_values
+
+  before_validation :sanitize_html
   before_validation :choose_refname
+
   validates_presence_of :project_id, :field_type, :name
+
   validates_uniqueness_of :name, scope: :project_id, case_sensitive: false
   validates_uniqueness_of :refname, scope: :project_id, case_sensitive: false
+
   validate :validate_values
   validate :unique_name
 
@@ -34,6 +41,12 @@ class FormulaField < ActiveRecord::Base
 
   def default_values
     self.name ||= Field.get_next_name project, field_type
+  end
+
+  def sanitize_html
+    # Strip HTML tags from input
+    self.name = strip_tags(name)
+    self.unit = strip_tags(unit)
   end
 
   def choose_refname

--- a/test/integration/user_interactions_test.rb
+++ b/test/integration/user_interactions_test.rb
@@ -16,4 +16,26 @@ class UserInteractionsTest < IntegrationTest
     visit project_path(@slick_project)
     assert page.has_no_content?('Edit'), 'Edit button appears on project that the user does not own.'
   end
+
+  test 'try to inject code into data set' do
+    # Make sure that code injection cannot happen anymore
+    login('pson@cs.uml.edu', '12345')
+
+    click_on 'Projects'
+    find('#project_title').set('Code Injection Test')
+    click_on 'Create Project'
+
+    find('#manual_fields').click
+    click_on 'Add Text'
+    fill_in 'text_1', with: '<script>alert(1)</script>'
+    click_on 'Save and Return'
+
+    assert page.has_no_content?('<script>'), 'Users should not be able to inject code into the webpage.'
+
+    click_on 'Manual Entry'
+    first('.editor-text').set('<h1>Testing...</h1>')
+    find('#edit_table_save_1').click
+
+    assert page.has_no_content?('<h1>'), 'Users should not be able to inject code into the webpage.'
+  end
 end


### PR DESCRIPTION
For #2413.
Input sanitization is done at the database level, so even data coming from APIs and CSVs gets sanitized.
All HTML tags are stripped away, which is fine because I can't think of a use case when someone would need \<brackets\> in their dataset.