### PR TITLE
Group-by option changes automatically when opening Photo vis.

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/photos.coffee
+++ b/app/assets/javascripts/visualizations/highvis/photos.coffee
@@ -35,6 +35,10 @@ $ ->
 
       start: ->
         super()
+        
+        # Photos doesn't have any fancy group by options, so set it to a default
+        # on load so the pictues actually show.
+        $('#group-by').val(data.COMBINED_FIELD).change()
 
       end: ->
         super()


### PR DESCRIPTION
For #2416.
Simple on-line fix.