### PR TITLE
Users can once again use the API to upload media objects to data sets with contributor keys

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -506,8 +506,6 @@ $ ->
         $('#period-list').val(globals.configs.periodMode)
 
         $('#period-list').change =>
-          console.log('Period:')
-          console.log($('#period-list').val())
           globals.configs.periodMode = $('#period-list').val()
           if $('#period-list').val() != 'off'
             globals.configs.isPeriod = true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -132,7 +132,6 @@ class ApplicationController < ActionController::Base
       key = project.contrib_keys.find_by_key(params[:contribution_key])
       if project && !key.nil? && data_set.key == key.name
         if params.key? :contributor_name
-          @cur_user = User.find_by_id(project.owner.id)
           owner = User.find_for_database_authentication(id: project.owner.id)
           sign_in('user', owner)
         else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -133,6 +133,8 @@ class ApplicationController < ActionController::Base
       if project && !key.nil? && data_set.key == key.name
         if params.key? :contributor_name
           @cur_user = User.find_by_id(project.owner.id)
+          owner = User.find_for_database_authentication(id: project.owner.id)
+          sign_in('user', owner)
         else
           respond_to do |format|
             format.json { render json: { msg: 'Missing contributor name' }, status: :unprocessable_entity }


### PR DESCRIPTION
For #2421.
This was broken by the move to Devise because a single line of code was not changed with the rest. That line has been updated, and now everything works like a charm.