### PR TITLE
Table no longer shows [NaN] when filtering by string.

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/filters.coffee
+++ b/app/assets/javascripts/visualizations/highvis/filters.coffee
@@ -43,6 +43,8 @@ $ ->
       f.opName    = globals.filterNames[f.op]
       formatter =
         if f.field is data.timeFields[0] then globals.dateFormatter
+        else if f.field in data.textFields then (str) ->
+          return str
         else data.precisionFilter
 
       if f.value?


### PR DESCRIPTION
For #2410.
The source of the issue was that the data precision filter was being applied to the strings, which would return NaN. For the sake of simplicity, I just added a filter for strings that simply returns the string.

I also broke table filtering in #2418, so I fixed it here.