### PR TITLE
Reordering or adding fields no longer breaks the vis

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -39,6 +39,10 @@ $ ->
 
         globals.configs.isPeriod ?= false # Controls how series are constructed in update(). 
         globals.configs.periodMode ?= 'off' # Changes when a period option is selected.
+        
+        # globals for saving the unique field ids, in case fields were reordered/new fields were added
+        globals.configs.fieldSelectionIds ?= []
+        globals.configs.groupByFieldId ?= -1
 
       ANALYSISTYPE_TOTAL:      0
       ANALYSISTYPE_MAX:        1
@@ -64,6 +68,7 @@ $ ->
         ( data.hasTimeData is false or data.timeType == data.GEO_TIME )
           data.setGroupIndex(data.COMBINED_FIELD)
           globals.configs.groupById = data.COMBINED_FIELD
+          
         @drawControls()
         @update()
         $('#vis-ctrls').scrollTop(toolScroll)
@@ -74,6 +79,11 @@ $ ->
       Derived classes should overload to reload content.
       ###
       update: ->
+        # Update the ids for field selection in case they were changed
+        globals.configs.fieldSelectionIds = []
+        for field in globals.configs.fieldSelection
+          globals.configs.fieldSelectionIds.push(data.fields[field].fieldID)
+        globals.configs.groupByFieldId = data.fields[globals.configs.groupById].fieldID
 
       ###
       Default delayed update simply updates

--- a/app/assets/javascripts/visualizations/highvis/pie.coffee
+++ b/app/assets/javascripts/visualizations/highvis/pie.coffee
@@ -133,3 +133,4 @@ $ ->
       globals.pie = new Pie 'pie-canvas'
     else
       globals.pie = new DisabledVis 'pie-canvas'
+      

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -51,6 +51,8 @@ $ ->
         @updateOnZoom = true
 
         @configs.mode ?= @SYMBOLS_MODE
+
+        @configs.xAxisId ?= -1
         @configs.xAxis ?= data.normalFields[0]
         # TODO write a migration to nuke @configs.yAxis
         @configs.advancedTooltips ?= 0
@@ -77,6 +79,14 @@ $ ->
         @configs.fullDetail ?= 0
 
       start: (animate = true) ->
+        # Reset the xAxis in case a new field was added or fields were reordered
+        if not @isScatter? then @configs.xAxis = data.timeFields[0]
+        else if @configs.xAxisId == -1 then @configs.xAxis = 0
+        else
+          fieldIds = for field in data.fields
+            field.fieldID
+          @configs.xAxis = fieldIds.indexOf(@configs.xAxisId)
+
         super(animate)
 
       storeXBounds: (bounds) ->
@@ -240,6 +250,9 @@ $ ->
       update: () ->
         # Remove all series and draw legend
         super()
+
+        @configs.xAxisId = data.fields[@configs.xAxis].fieldID
+
         title =
           text: fieldTitle data.fields[@configs.xAxis]
         @chart.xAxis[0].setTitle title, false

--- a/app/assets/javascripts/visualizations/visualizations.js.coffee
+++ b/app/assets/javascripts/visualizations/visualizations.js.coffee
@@ -120,6 +120,19 @@ $ ->
         vis  = eval "globals.#{visName.toLowerCase()}"
         if vis? and savedGlobals[visName]?
           $.extend(vis.configs, savedGlobals[visName])
+          
+      # Reset correct field indices in case the fields were reordered/new fields were added
+      fieldIds = for field in data.fields
+        field.fieldID
+        
+      if globals.configs.fieldSelectionIds?
+        globals.configs.fieldSelection = []
+        for id in globals.configs.fieldSelectionIds
+          if id in fieldIds
+            globals.configs.fieldSelection.push(fieldIds.indexOf(id))
+            
+      if globals.configs.groupByFieldId? and globals.configs.groupByFieldId != -1
+        globals.configs.groupById = fieldIds.indexOf(globals.configs.groupByFieldId)
 
       delete data.savedGlobals
 


### PR DESCRIPTION
For #2405.
This is a long-standing bug, and I'm surprised it's taken this long for someone to notice it, but it is now fixed.
In the future: Try not to refer to objects solely by indices in an array, especially when those indices can change without the program knowing (which is how iSENSE has worked for the past 3 years).