### PR TITLE
Camera marker no longer appears on map vis

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -244,24 +244,10 @@ $ ->
               strokeWeight: 2
               scale: 7
 
-            cameraSym =
-              fillColor: color
-              fillOpacity: 1
-              path: 'M 20, 10
-                      m -6, 0
-                      a 6,6 0 1,0 12,0
-                      a 6,6 0 1,0 -12,0
-                      M 0 20 L 40 20 L 40 0 L 34 0 L 34 -2 L 38 -2 L 38 0 L 40 0  L 0 0 Z'
-              strokeColor: "#000"
-              strokeWeight: 2
-              scale: .8
-
-            symbol = if data.metadata[metaIndex].photos.length > 0 then cameraSym else pinSym
-
             newMarker = new google.maps.Marker
               position: latlng
               animation: google.maps.Animation.DROP
-              icon: symbol
+              icon: pinSym
               desc: label
               visible: ((groupIndex in data.groupSelection) and
                 Boolean(@configs.visibleMarkers))


### PR DESCRIPTION
Reverts #2134.
I received an executive order to remove the special camera marker icon on the map because it was "ugly". Points with images now look the same as all the rest. May revisit this later, along with a reworking of images.