### PR TITLE
A few more patches to fix the Field Reordering bug

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -41,6 +41,19 @@ $ ->
         # Default Sort
         fs = globals.configs.fieldSelection
         @configs.sortField ?= if fs? then fs[0] else @SORT_DEFAULT
+        @configs.sortFieldId ?=
+          if @configs.sortField == @SORT_DEFAULT
+            -2
+          else
+            data.fields[@configs.sortField].fieldID
+        
+        if @configs.sortFieldId == -2 then @configs.sortField = @SORT_DEFAULT
+        else if @configs.sortFieldId == -1 then @configs.sortField = 0
+        else
+          fieldIds = for field in data.fields
+            field.fieldID
+          @configs.sortField = fieldIds.indexOf(@configs.sortFieldId)
+
 
         super()
 
@@ -113,6 +126,8 @@ $ ->
         super()
 
         fieldSelection = globals.configs.fieldSelection
+
+        @configs.sortFieldId = if @configs.sortField == @SORT_DEFAULT then -2 else data.fields[@configs.sortField].fieldID
         
         # Get the column data
         groupedData = {}

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -127,7 +127,8 @@ $ ->
 
         fieldSelection = globals.configs.fieldSelection
 
-        @configs.sortFieldId = if @configs.sortField == @SORT_DEFAULT then -2 else data.fields[@configs.sortField].fieldID
+        @configs.sortFieldId =
+          if @configs.sortField == @SORT_DEFAULT then -2 else data.fields[@configs.sortField].fieldID
         
         # Get the column data
         groupedData = {}

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -52,7 +52,7 @@ $ ->
 
         @configs.mode ?= @SYMBOLS_MODE
 
-        @configs.xAxisId ?= -1
+        # @configs.xAxisId ?= -1
         @configs.xAxis ?= data.normalFields[0]
         # TODO write a migration to nuke @configs.yAxis
         @configs.advancedTooltips ?= 0
@@ -79,6 +79,7 @@ $ ->
         @configs.fullDetail ?= 0
 
       start: (animate = true) ->
+        @configs.xAxisId ?= data.fields[@configs.xAxis].fieldID
         # Reset the xAxis in case a new field was added or fields were reordered
         if not @isScatter? then @configs.xAxis = data.timeFields[0]
         else if @configs.xAxisId == -1 then @configs.xAxis = 0

--- a/app/assets/javascripts/visualizations/visualizations.js.coffee
+++ b/app/assets/javascripts/visualizations/visualizations.js.coffee
@@ -124,8 +124,6 @@ $ ->
       # Reset correct field indices in case the fields were reordered/new fields were added
       fieldIds = for field in data.fields
         field.fieldID
-        
-      console.log(globals.configs.fieldSelectionIds)
 
       if globals.configs.fieldSelectionIds?
         if globals.configs.fieldSelectionIds.length != 0


### PR DESCRIPTION
For #2405.
This pull request is an extension of #2423. The default sort on bar chart now correctly changes itself when the fields were reordered, and a quick fix to scatter should stop it from resetting the defaults on existing projects.