### PR TITLE
Users can now upload App Inventor project files

### DIFF
--- a/lib/file_uploader.rb
+++ b/lib/file_uploader.rb
@@ -33,7 +33,9 @@ class FileUploader
     # Presentation
     'pez', 'sti', 'sxi',
     # Google
-    'gdoc', 'gsheet'
+    'gdoc', 'gsheet',
+    # App Inventor
+    'aia'
   ]
 
   @converted_csv = nil


### PR DESCRIPTION
For #2432.
Just had to add .aia to the list of valid media extensions.