### PR TITLE
Changed devise reset email to use HTTPS

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,5 +71,5 @@ Rsense::Application.configure do
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
-  config.action_mailer.default_url_options = { host: `hostname`.chomp }
+  config.action_mailer.default_url_options = { protocol: 'https', host: `hostname`.chomp }
 end


### PR DESCRIPTION
For #2392.
We won't be able to see if this works until it's in production, but this is [how Devise says to do it](https://github.com/plataformatec/devise/wiki/How-To:-Use-SSL-(HTTPS)).