### PR TITLE
Users can now disable points from the scatter vis

### DIFF
--- a/app/assets/javascripts/templates/visualizations/controls/scatter-tools.hbs
+++ b/app/assets/javascripts/templates/visualizations/controls/scatter-tools.hbs
@@ -58,6 +58,13 @@
     </div>
       <button id="set-axis-button" data-log-id="set-axis-size" class="btn btn-default">Set Axis Size</button>
   </div>
+  <div class="vis-ctrl-subblock">
+    <h4 class="vis-ctrl-subtitle">Disable Points</h4>
+    <div style="width: 70%;">
+      <button id="disable-point-button" data-log-id="disable-point" class="btn btn-default" style="display: block; width: 100%;" disabled>Disable Selected Point</button>
+      <button id="enable-points-button" data-log-id="enable-points" class="btn btn-default" style="display: block; width: 100%;">Enable All Points</button>
+    </div>
+  </div>
 {{/if}}
 {{{period}}}
 <div class="vis-ctrl-subblock">

--- a/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
+++ b/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
@@ -123,9 +123,19 @@ $ ->
     ###
     Selects data with potential filters
     ###
-    globals.getData = (clip = false, filters = []) ->
+    globals.getData = (clip = false, filters = [], disabledPoints = []) ->
       # Select all the data
       dp = data.dataPoints
+      if disabledPoints.length > 0
+        dp = dp.filter (p) =>
+          obj = {pointId: p[0], dataSetId: globals.getDataSetId(p[1])}
+          pass = true
+          for point in disabledPoints
+            if JSON.stringify(point) == JSON.stringify(obj)
+              pass = false
+              break
+          return pass
+
       unless clip and globals.configs.clippingMode then return dp
 
       # Ensure filters is a list
@@ -143,6 +153,16 @@ $ ->
         dp = dp.filter(func)
 
       return dp
+
+    ###
+    Returns the Data Set ID given the data set name from the 
+    datapoint object, of the form: "[dataset name]([dataset id])".
+    Does some fancy Regex magic in case the user includes numbers
+    inside of parentheses in the data set name.
+    ###
+    globals.getDataSetId = (dsetName) ->
+      matches = dsetName.match(/\([0-9]*\)/g)
+      return /\(([0-9]*)\)/i.exec(matches[matches.length - 1])[1]
 
     ###
     Selects data in an x,y object format of the given group.

--- a/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
+++ b/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
@@ -127,7 +127,7 @@ $ ->
       # Select all the data
       dp = data.dataPoints
       if disabledPoints.length > 0
-        dp = dp.filter (p) =>
+        dp = dp.filter (p) ->
           obj = {pointId: p[0], dataSetId: globals.getDataSetId(p[1])}
           pass = true
           for point in disabledPoints
@@ -155,7 +155,7 @@ $ ->
       return dp
 
     ###
-    Returns the Data Set ID given the data set name from the 
+    Returns the Data Set ID given the data set name from the
     datapoint object, of the form: "[dataset name]([dataset id])".
     Does some fancy Regex magic in case the user includes numbers
     inside of parentheses in the data set name.

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -134,7 +134,6 @@ $ ->
                     root = ele.parent()
                     root.append ele
                   select: () ->
-                    console.log(@)
                     self.selectedDataSetId = globals.getDataSetId(@.datapoint[1])
                     self.selectedPointId = @.datapoint[0]
                     $('#disable-point-button').prop("disabled", false)
@@ -640,7 +639,6 @@ $ ->
           $('#disable-point-button').prop("disabled", true)
           $('#enable-points-button').prop("disabled", false)
           @configs.disabledPoints.push({pointId: @selectedPointId, dataSetId: @selectedDataSetId})
-          console.log(@configs.disabledPoints)
           @start()
 
         $('#enable-points-button').click (e) =>

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -52,6 +52,12 @@ $ ->
 
         @configs.mode ?= @SYMBOLS_MODE
 
+        # Used to remember the IDs of the selected point on the chart
+        @selectedPointId = -1
+        @selectedDataSetId = -1
+
+        @configs.disabledPoints ?= []
+
         # @configs.xAxisId ?= -1
         @configs.xAxis ?= data.normalFields[0]
         # TODO write a migration to nuke @configs.yAxis
@@ -115,6 +121,7 @@ $ ->
           plotOptions:
             scatter:
               animation: false
+              allowPointSelect: true
               marker:
                 states:
                   hover:
@@ -126,6 +133,11 @@ $ ->
                     ele = $(@.graphic.element)
                     root = ele.parent()
                     root.append ele
+                  select: () ->
+                    console.log(@)
+                    self.selectedDataSetId = globals.getDataSetId(@.datapoint[1])
+                    self.selectedPointId = @.datapoint[0]
+                    $('#disable-point-button').prop("disabled", false)
 
           groupBy = ''
           $('#groupSelector').find('option').each (i,j) ->
@@ -258,7 +270,7 @@ $ ->
           text: fieldTitle data.fields[@configs.xAxis]
         @chart.xAxis[0].setTitle title, false
 
-        dp = globals.getData(true, globals.configs.activeFilters)
+        dp = globals.getData(true, globals.configs.activeFilters, @configs.disabledPoints)
 
         # Helper Function to modify the date based on period option on Timeline
         # Dates are normalized to 1990 so that when they are graphed, dates fall
@@ -621,6 +633,21 @@ $ ->
           @configs.mode = Number e.target.value
           @start()
 
+        if @configs.disabledPoints.length == 0
+          $('#enable-points-button').prop("disabled", true)
+
+        $('#disable-point-button').click (e) =>
+          $('#disable-point-button').prop("disabled", true)
+          $('#enable-points-button').prop("disabled", false)
+          @configs.disabledPoints.push({pointId: @selectedPointId, dataSetId: @selectedDataSetId})
+          console.log(@configs.disabledPoints)
+          @start()
+
+        $('#enable-points-button').click (e) =>
+          $('#enable-points-button').prop("disabled", true)
+          @configs.disabledPoints = []
+          @start()
+
         $('#ckbx-tooltips').click (e) =>
           @configs.advancedTooltips = (@configs.advancedTooltips + 1) % 2
           @start()
@@ -829,7 +856,7 @@ $ ->
           name += desc + "function of <strong>#{xAxisName}</strong>"
 
           # List of (x,y) points to be used in calculating regression
-          dp = globals.getData(true, globals.configs.activeFilters)
+          dp = globals.getData(true, globals.configs.activeFilters, @configs.disabledPoints)
           xyData = data.multiGroupXYSelector(@configs.xAxis, yAxisIndex,
             data.groupSelection, dp)
           xMax = window.globals.curVis.configs.xBounds.max
@@ -1024,7 +1051,7 @@ $ ->
 
         for filter in filters
           globals.configs.activeFilters.push(filter)
-
+    
     if "Scatter" in data.relVis
       globals.scatter = new Scatter "scatter-canvas"
     else


### PR DESCRIPTION
For #2343.
Works well for removing outliers for regressions.
Initially I wanted to have a little pop-up/tooltip under the point when you click on it, but it would look crowded in addition to the existing tooltip, and it was prohibitively complicated to get it working that way with Highcharts.