### PR TITLE
Fields can no longer be deleted when the project has data sets.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -286,8 +286,19 @@ class ProjectsController < ApplicationController
     success = true
 
     ActiveRecord::Base.transaction do
-      # Deletion silently fails upon any error
-      delete_hidden_fields(Field, params[:hidden_deleted_fields])
+      if params[:hidden_deleted_fields].length != 0
+        if @project.data_sets.length > 0
+          respond_to do |format|
+            format.html do
+              redirect_to [:show, @project],
+              alert: "Can't delete fields when you have existing data sets."
+            end
+            format.json { render json: {errors: ["Can't delete fields when you have existing data sets. Delete existing data sets and try again."]}, status: :forbidden }
+          end
+          return
+        end
+        delete_hidden_fields(Field, params[:hidden_deleted_fields])
+      end
 
       # Update existing fields, create restrictions if any exist
       @project.fields.each do |field|

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -293,7 +293,7 @@ class ProjectsController < ApplicationController
               redirect_to [:show, @project],
               alert: "Can't delete fields when you have existing data sets."
             end
-            format.json { render json: {errors: ["Can't delete fields when you have existing data sets. Delete existing data sets and try again."]}, status: :forbidden }
+            format.json { render json: { errors: ["Can't delete fields when you have existing data sets. Delete existing data sets and try again."] }, status: :forbidden }
           end
           return
         end


### PR DESCRIPTION
For #2319.
I'm guessing this bug exists because whoever originally wrote the code for delete_hidden_fields assumed that field.destroy would run the field_controller's destroy, which handles the error correctly, but it actually just jumps straight to the model and deletes it without checking anything.
If you do manage to press the delete button when you're not supposed to, it won't actually delete anything anymore and display an error. It also won't put those fields back onto the table, but since the user isn't supposed to be able to do that anyway, I think it's fine.