### PR TITLE
"Reset Defaults" button added to Edit Project page

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -132,6 +132,9 @@ class ProjectsController < ApplicationController
   def update
     @project = Project.find(params[:id])
     update = project_params
+    # If the user hit the "Reset Defaults" button, set globals to nil.
+    # nil can't be passed from the url, so do it here.
+    update[:globals] = nil if update[:globals] == ''
 
     # ADMIN REQUEST
     if current_user.try(:admin)

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -56,7 +56,7 @@
           <span class="help-block">Hiding a project will hide it from public view. You will still be able
             to reach the project through your profile page.</span>
         </div>
-      </div> 
+      </div>
 
       <!-- admin section -->
       <% if can_admin? @project%>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -56,7 +56,7 @@
           <span class="help-block">Hiding a project will hide it from public view. You will still be able
             to reach the project through your profile page.</span>
         </div>
-      </div>
+      </div> 
 
       <!-- admin section -->
       <% if can_admin? @project%>
@@ -92,6 +92,19 @@
           </div>
         </div>
       <% end %>
+
+      <div class="form-group">
+        <div class="checkbox">
+          <% res = 'Reset Defaults' %>
+          <% cls = 'mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--blue' %>
+          <%= link_to raw(res),
+              project_path(@project, project: { globals: nil, default_vis: "none" }),
+              { method: :put, data: { confirm: 'Really reset default options?' },
+              class: cls } %>
+          <span class="help-block">Reset the default options on the visualization page. 
+            If your visualization is behaving incorrectly, try using this option.</span>
+        </div>
+      </div>
 
       <div class="form-group">
         <div class="checkbox">


### PR DESCRIPTION
For #2443.
The button sets project.globals to nil. Hopefully this button will come in handy if we ever see another "This project breaks vis badly" issue report (#2261).