### PR TITLE
Delete Selected Data Sets refreshes Project page

### DIFF
--- a/app/assets/javascripts/projects/show.js.coffee
+++ b/app/assets/javascripts/projects/show.js.coffee
@@ -185,13 +185,8 @@ IS.onReady "projects/show", ->
         type: "delete"
         dataType: "json"
         success: ->
-          recolored = false
-          tbody = rows[0].parents('tbody')
-          for row in rows
-            row.fadeOut ->
-              row.remove()
-          tbody.recolor_rows(recolored)
-          recolored = true
+          # reload page without scrolling back to previous position, so we can see the message at the top.
+          window.location.href = window.location.href
         error: (msg) ->
           response = $.parseJSON msg['responseText']
           error_message = response.error

--- a/app/controllers/data_sets_controller.rb
+++ b/app/controllers/data_sets_controller.rb
@@ -183,6 +183,7 @@ class DataSetsController < ApplicationController
       end
       @project ||= @dataset_array[0].project
     end
+    amount = @dataset_array.length
 
     if @project.lock? and !can_edit?(@project)
       redirect_to @project, alert: 'Project is locked'
@@ -197,9 +198,11 @@ class DataSetsController < ApplicationController
           format.html { redirect_to project_path(@data_set.project.id), notice: 'Data set could not be removed' }
           format.json { render json: { error: 'Unprocessable Entity' }, status: :unprocessable_entity }
         end
+        return
       end
     end
 
+    flash[:notice] = "Successfully deleted #{amount} data set" + (amount == 1 ? '' : 's') + '.'
     respond_to do |format|
       format.html { redirect_to request.referrer, notice: 'Data sets removed' }
       format.json { render json: {}, status: :ok }


### PR DESCRIPTION
There is currently an issue with removing multiple rows from the JQuery data set table on the project page. For now, The page will just refresh after the delete occurs.