### PR TITLE
Group titles no longer lose capitalization.

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
+++ b/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
@@ -169,7 +169,7 @@ $ ->
     ###
     data.xySelector = (xIndex, yIndex, groupIndex, dp) ->
       rawData = dp.filter (p) =>
-        group = (String p[globals.configs.groupById]).toLowerCase() == @groups[groupIndex]
+        group = (String p[globals.configs.groupById]).toLowerCase() == @groups[groupIndex].toLowerCase()
         notNull = (p[xIndex] isnt null) and (p[yIndex] isnt null)
         notNaN = (not isNaN(p[xIndex])) and (not isNaN(p[yIndex]))
 
@@ -204,7 +204,7 @@ $ ->
       groupById = globals.configs.groupById
 
       filterFunc = (p) =>
-        (String p[groupById]).toLowerCase() == @groups[groupIndex]
+        (String p[groupById]).toLowerCase() == @groups[groupIndex].toLowerCase()
 
       newFilterFunc = if nans
         filterFunc
@@ -347,7 +347,7 @@ $ ->
     ###
     data.setIndexFromGroups = (gIndex) ->
       filterFunc = (dp) =>
-        (String dp[gIndex]).toLowerCase() == @groups[groupIndex]
+        (String dp[gIndex]).toLowerCase() == @groups[groupIndex].toLowerCase()
 
       rawData = for group, groupIndex in @groups
         selectedPoints = @dataPoints.filter filterFunc
@@ -388,7 +388,7 @@ $ ->
 
       for dp in @dataPoints
         if dp[gIndex] isnt null
-          result[String(dp[gIndex]).toLowerCase()] = true
+          result[String(dp[gIndex])] = true
 
       groups = for keys of result
         keys

--- a/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
+++ b/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
@@ -169,7 +169,7 @@ $ ->
     ###
     data.xySelector = (xIndex, yIndex, groupIndex, dp) ->
       rawData = dp.filter (p) =>
-        group = (String p[globals.configs.groupById]).toLowerCase() == @groups[groupIndex].toLowerCase()
+        group = (String p[globals.configs.groupById]) == @groups[groupIndex]
         notNull = (p[xIndex] isnt null) and (p[yIndex] isnt null)
         notNaN = (not isNaN(p[xIndex])) and (not isNaN(p[yIndex]))
 
@@ -204,7 +204,7 @@ $ ->
       groupById = globals.configs.groupById
 
       filterFunc = (p) =>
-        (String p[groupById]).toLowerCase() == @groups[groupIndex].toLowerCase()
+        (String p[groupById]) == @groups[groupIndex]
 
       newFilterFunc = if nans
         filterFunc
@@ -347,7 +347,7 @@ $ ->
     ###
     data.setIndexFromGroups = (gIndex) ->
       filterFunc = (dp) =>
-        (String dp[gIndex]).toLowerCase() == @groups[groupIndex].toLowerCase()
+        (String dp[gIndex]) == @groups[groupIndex]
 
       rawData = for group, groupIndex in @groups
         selectedPoints = @dataPoints.filter filterFunc

--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -160,7 +160,8 @@ $ ->
             if (lat is null) or (lon is null)
               return
 
-            groupIndex = data.groups.indexOf(
+            groupsLowerCase = (g.toLowerCase() for g in data.groups)
+            groupIndex = groupsLowerCase.indexOf(
               String(dp[globals.configs.groupById]).toLowerCase())
             color = globals.getColor(groupIndex)
             latlng = new google.maps.LatLng(lat, lon)

--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -160,9 +160,8 @@ $ ->
             if (lat is null) or (lon is null)
               return
 
-            groupsLowerCase = (g.toLowerCase() for g in data.groups)
-            groupIndex = groupsLowerCase.indexOf(
-              String(dp[globals.configs.groupById]).toLowerCase())
+            groupIndex = data.groups.indexOf(
+              String(dp[globals.configs.groupById]))
             color = globals.getColor(groupIndex)
             latlng = new google.maps.LatLng(lat, lon)
 

--- a/app/assets/javascripts/visualizations/highvis/table.coffee
+++ b/app/assets/javascripts/visualizations/highvis/table.coffee
@@ -102,12 +102,12 @@ $ ->
           fieldTitle(field)
 
         # Build the data for the table
-        visGroups = (g.toLowerCase() for g, i in data.groups when i in data.groupSelection)
+        visGroups = (g for g, i in data.groups when i in data.groupSelection)
 
         rows = []
         dp = globals.getData(true, globals.configs.activeFilters)
         gbid = globals.configs.groupById
-        for point in dp when String(point[gbid]).toLowerCase() in visGroups
+        for point in dp when String(point[gbid]) in visGroups
           row = {}
           index = 0
           for d, i in point when i in @configs.tableFields

--- a/app/assets/javascripts/visualizations/highvis/table.coffee
+++ b/app/assets/javascripts/visualizations/highvis/table.coffee
@@ -102,7 +102,7 @@ $ ->
           fieldTitle(field)
 
         # Build the data for the table
-        visGroups = (g for g, i in data.groups when i in data.groupSelection)
+        visGroups = (g.toLowerCase() for g, i in data.groups when i in data.groupSelection)
 
         rows = []
         dp = globals.getData(true, globals.configs.activeFilters)

--- a/app/assets/javascripts/visualizations/highvis/visUtils.coffee
+++ b/app/assets/javascripts/visualizations/highvis/visUtils.coffee
@@ -325,13 +325,15 @@ $ ->
       for group in data.groups
         timeMins.push Number.MAX_VALUE
 
+      groupsLowerCase = (g.toLowerCase() for g in data.groups)
+
       for datapoint in data.dataPoints
-        group = data.groups.indexOf (String datapoint[globals.configs.groupById]).toLowerCase()
+        group = groupsLowerCase.indexOf (String datapoint[globals.configs.groupById]).toLowerCase()
         time = datapoint[sourceField].valueOf()
         timeMins[group] = Math.min timeMins[group], datapoint[sourceField]
 
       for datapoint in data.dataPoints
-        group = data.groups.indexOf (String datapoint[globals.configs.groupById]).toLowerCase()
+        group = groupsLowerCase.indexOf (String datapoint[globals.configs.groupById]).toLowerCase()
         curTime = datapoint[sourceField].valueOf()
         datapoint.push (curTime - timeMins[group]) / 1000.0
 

--- a/app/assets/javascripts/visualizations/highvis/visUtils.coffee
+++ b/app/assets/javascripts/visualizations/highvis/visUtils.coffee
@@ -325,15 +325,13 @@ $ ->
       for group in data.groups
         timeMins.push Number.MAX_VALUE
 
-      groupsLowerCase = (g.toLowerCase() for g in data.groups)
-
       for datapoint in data.dataPoints
-        group = groupsLowerCase.indexOf (String datapoint[globals.configs.groupById]).toLowerCase()
+        group = data.groups.indexOf (String datapoint[globals.configs.groupById]).toLowerCase()
         time = datapoint[sourceField].valueOf()
         timeMins[group] = Math.min timeMins[group], datapoint[sourceField]
 
       for datapoint in data.dataPoints
-        group = groupsLowerCase.indexOf (String datapoint[globals.configs.groupById]).toLowerCase()
+        group = data.groups.indexOf (String datapoint[globals.configs.groupById]).toLowerCase()
         curTime = datapoint[sourceField].valueOf()
         datapoint.push (curTime - timeMins[group]) / 1000.0
 


### PR DESCRIPTION
For #2265. For real this time.
Group titles should no longer show as all-lowercase, all the time anymore. This has the side effect of making different capitalizations of the same word (e.g. USA vs usa) be put into different groups. @fgmart  decided that this was the behavior we should go with.