### PR TITLE
No longer need to double click a cell to bring focus back on manualEntry table

### DIFF
--- a/app/assets/javascripts/data_sets/editTable.js.coffee
+++ b/app/assets/javascripts/data_sets/editTable.js.coffee
@@ -186,6 +186,10 @@ class Grid
 
     @grid.onClick.subscribe (e, args) =>
       cell = @grid.getCellFromEvent e
+      activeCell = @grid.getActiveCell()
+      # return focus to active cell if we are returning to the table. See #2323.
+      if activeCell? and cell.row == activeCell.row and cell.cell == activeCell.cell
+        @grid.setActiveCell(cell)
       if cell.cell == @grid.getColumns().length - 1
         @queueDeleteRow(cell.row)
         if @grid.getDataLength() == 0


### PR DESCRIPTION
For #2323.
For whatever reason, clicking outside the table would do weird stuff with activeCell on slickgrid. Slickgrid knew that you were clicking a cell (printing out the cell from @grid.onClick would show the correct cell), but it would just not set it active for editing. This fix simply sets the activeCell attribute if the clicked cell is the same as the previous activeCell.