### PR TITLE
Scatter tooltip no longer uses data from bottom-most point when points overlap

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -176,6 +176,9 @@ $ ->
                   #{fieldUnit(data.fields[index], false)}</strong></td></tr>"
                   str += "</table>"
             useHTML: true
+            # Turning 'shared' on when in scatter fixes Issue #2322.
+            # Note that 'shared' doesn't function in scatter mode, but somehow fixes our issue.
+            shared: if @configs.mode is @LINES_MODE then false else true
             hideDelay: 0
 
           xAxis: [{


### PR DESCRIPTION
For #2322.
The fix for this ended up being really weird. I stared at scatter.coffee for hours, making random little changes, and got nowhere. On a whim, I added the option "shared: true" to the tooltip, and the issue disappeared. We will watch it to make sure this doesn't break anything else.