### PR TITLE
Removed hidden fields from Scatterplot Detailed Tool Tips

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -162,7 +162,7 @@ $ ->
                     else
                       @point.datapoint[fieldIndex]
                     
-                    if field.fieldName isnt 'Number Fields' and field.fieldName isnt 'Time Period'
+                    if field.fieldName isnt 'Number Fields' and field.fieldName isnt 'Time Period' and field.fieldName isnt 'Combined Data Sets'
                       str += "<tr><td>#{field.fieldName}</td>"
                       str += "<td><strong>#{dat}</strong></td></tr>"
 

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -154,8 +154,6 @@ $ ->
                   str += "#{@series.name.group}</div><br>"
                   str += "<table>"
 
-                  #str += "<tr><td>Group by: </td>" + "\t" + "<td>#{groupBy} </td> </tr>"
-
                   for field, fieldIndex in data.fields when @point.datapoint[fieldIndex] isnt null
                     dat = if (Number field.typeID) is data.types.TIME
                       (globals.dateFormatter @point.datapoint[fieldIndex])

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -153,16 +153,18 @@ $ ->
                   str  = "<div style='width:100%;text-align:center;color:#{@series.color};'> "
                   str += "#{@series.name.group}</div><br>"
                   str += "<table>"
-                  str += "<tr><td>Group by: </td>" + "\t" + "<td>#{groupBy} </td> </tr>"
+
+                  #str += "<tr><td>Group by: </td>" + "\t" + "<td>#{groupBy} </td> </tr>"
 
                   for field, fieldIndex in data.fields when @point.datapoint[fieldIndex] isnt null
                     dat = if (Number field.typeID) is data.types.TIME
                       (globals.dateFormatter @point.datapoint[fieldIndex])
                     else
                       @point.datapoint[fieldIndex]
-
-                    str += "<tr><td>#{field.fieldName}</td>"
-                    str += "<td><strong>#{dat}</strong></td></tr>"
+                    
+                    if field.fieldName isnt 'Number Fields' and field.fieldName isnt 'Time Period'
+                      str += "<tr><td>#{field.fieldName}</td>"
+                      str += "<td><strong>#{dat}</strong></td></tr>"
 
                   str += "</table>"
                 else

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -160,7 +160,7 @@ $ ->
                     else
                       @point.datapoint[fieldIndex]
                     
-                    if field.fieldName isnt 'Number Fields' and 
+                    if field.fieldName isnt 'Number Fields' and
                     field.fieldName isnt 'Time Period' and
                     field.fieldName isnt 'Combined Data Sets'
                       str += "<tr><td>#{field.fieldName}</td>"

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -160,7 +160,8 @@ $ ->
                     else
                       @point.datapoint[fieldIndex]
                     
-                    if field.fieldName isnt 'Number Fields' and field.fieldName isnt 'Time Period' and field.fieldName isnt 'Combined Data Sets'
+                    if field.fieldName isnt 'Number Fields' and field.fieldName isnt 'Time Period' 
+                    and field.fieldName isnt 'Combined Data Sets'
                       str += "<tr><td>#{field.fieldName}</td>"
                       str += "<td><strong>#{dat}</strong></td></tr>"
 

--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -160,8 +160,9 @@ $ ->
                     else
                       @point.datapoint[fieldIndex]
                     
-                    if field.fieldName isnt 'Number Fields' and field.fieldName isnt 'Time Period' 
-                    and field.fieldName isnt 'Combined Data Sets'
+                    if field.fieldName isnt 'Number Fields' and 
+                    field.fieldName isnt 'Time Period' and
+                    field.fieldName isnt 'Combined Data Sets'
                       str += "<tr><td>#{field.fieldName}</td>"
                       str += "<td><strong>#{dat}</strong></td></tr>"
 


### PR DESCRIPTION
Issue #2457

Made it so that the detailed tool tips would not show hidden fields such as "Group By:", "Number Fields",  "Combined Data Sets", and "Time Period"




