### PR TITLE
Edit Data Set title on Vis Page size issue

### DIFF
--- a/app/views/shared/_title_and_menu.html.erb
+++ b/app/views/shared/_title_and_menu.html.erb
@@ -52,7 +52,7 @@
   </div>
   <% if edit %>
     <%= form_for obj do |ff| %>
-      <div id="title-and-menu-edit" class="input-group">
+      <div id="title-and-menu-edit" class="input-group hidden-xs hidden-sm">
         <%= ff.text_field :title, :value => obj.title.html_safe,
             class: "form-control" %>
         <div class="input-group-btn">

--- a/app/views/visualizations/_vis.html.erb
+++ b/app/views/visualizations/_vis.html.erb
@@ -47,69 +47,83 @@
     <div id="vis-header">
       <div id="vis-title-bar"
            <% if @presentation || !titleBar %> style="display:none" <% end %>>
-        <div id="vis-title-edit-btn" class="hidden-xs hidden-sm">
-          <div class="inline-block subtitle">
-            <% if obj && can_edit?(obj) %>
-              <div class="edit_menu inline-block" data-field="title"
-                   data-value="<%= obj.title.html_safe %>">
-                <div class="btn-group">
-                  <a class="btn btn-primary dropdown-toggle menu_edit_link"
-                     data-toggle="dropdown" href="#">
-                    Edit <span class="caret"></span>
-                  </a>
-                  <ul class="dropdown-menu pull-right" role="menu">
-                    <li role="presentation">
-                      <a class="menu_rename" role="menuitem"
-                         href="<%= url_for obj %>">
-                        <i class="fa fa-edit"></i> Edit Title
-                      </a>
-                    </li>
-                    <% if can_delete?(obj) %>
-                      <li role="presentation">
-                        <%= link_to obj, data: { confirm: "Are you sure?" },
-                            method: :delete,
-                            class: 'menu_delete' do %>
-                        <i style="color:red" class="fa fa-times-circle"></i>
-                        Delete
-                        <%= (s = obj.class.to_s) == 'DataSet' ?
-                            'Data Set' : s  %>
-                        <% end %>
-                      </li>
-                    <% end %>
-                  </ul>
+        <div class = "row"> 
+          
+          <div class = "col-md-8">
+   
+                <button id="ctrls-menu-btn"
+                          class="hamburger-menu btn btn-default down"
+                          <% if !controls %> style="display:none" <% end %>>
+                    <span class="hamburger-bar"></span>
+                    <span class="hamburger-bar"></span>
+                    <span class="hamburger-bar"></span>
+                </button>
+          
+  
+                <div id="vis-title" class="inline-block">
+                  <% if obj %>
+                    <%= title_and_edit_menu(obj) %>
+                  <% else %>
+                    Showing <%= @datasets.count %> Data Sets
+                  <% end %>
+                  <div class="subtitle" style="font-style: italic">
+                    <span>from&nbsp;</span>
+                    <i class='fa fa-folder-open'></i>
+                    <%= link_to project.title.html_safe, project, class: "link" %>
+                      by <i class='fa fa-user'></i>
+                    <%= link_to "#{project.owner.name}", owner, class: "link" %>
                 </div>
+
               </div>
-            <% end %>
+            
           </div>
-          <% if getLatest %>
-            <%= link_to "#{project_path(@project)}/data_sets",
-                { id:"refresh-data", class: "btn btn-default" } do %>
-              Get Latest Data
-              <%= content_tag(:i, ' ', class: 'fa fa-refresh') %>
-            <% end %>
-          <% end %>
-        </div>
-        <button id="ctrls-menu-btn"
-                class="hamburger-menu btn btn-default down"
-                <% if !controls %> style="display:none" <% end %>>
-          <span class="hamburger-bar"></span>
-          <span class="hamburger-bar"></span>
-          <span class="hamburger-bar"></span>
-        </button>
-        <div id="vis-title" class="inline-block">
-          <% if obj %>
-            <%= title_and_edit_menu(obj) %>
-          <% else %>
-            Showing <%= @datasets.count %> Data Sets
-          <% end %>
-          <div class="subtitle" style="font-style: italic">
-            <span>from&nbsp;</span>
-            <i class='fa fa-folder-open'></i>
-            <%= link_to project.title.html_safe, project, class: "link" %>
-              by <i class='fa fa-user'></i>
-            <%= link_to "#{project.owner.name}", owner, class: "link" %>
+        
+          <div class = "col-md-4">
+            <div id="vis-title-edit-btn" class="hidden-xs hidden-sm">
+              <div class="inline-block subtitle">
+                <% if obj && can_edit?(obj) %>
+                  <div class="edit_menu inline-block" data-field="title"
+                      data-value="<%= obj.title.html_safe %>">
+                    <div class="btn-group">
+                      <a class="btn btn-primary dropdown-toggle menu_edit_link"
+                        data-toggle="dropdown" href="#">
+                        Edit <span class="caret"></span>
+                      </a>
+                      <ul class="dropdown-menu pull-right" role="menu">
+                        <li role="presentation">
+                          <a class="menu_rename" role="menuitem"
+                            href="<%= url_for obj %>">
+                            <i class="fa fa-edit"></i> Edit Title
+                          </a>
+                        </li>
+                        <% if can_delete?(obj) %>
+                          <li role="presentation">
+                            <%= link_to obj, data: { confirm: "Are you sure?" },
+                                method: :delete,
+                                class: 'menu_delete' do %>
+                            <i style="color:red" class="fa fa-times-circle"></i>
+                            Delete
+                            <%= (s = obj.class.to_s) == 'DataSet' ?
+                                'Data Set' : s  %>
+                            <% end %>
+                          </li>
+                        <% end %>
+                      </ul>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+              <% if getLatest %>
+                <%= link_to "#{project_path(@project)}/data_sets",
+                    { id:"refresh-data", class: "btn btn-default" } do %>
+                  Get Latest Data
+                  <%= content_tag(:i, ' ', class: 'fa fa-refresh') %>
+                <% end %>
+              <% end %>
+            </div>
           </div>
         </div>
+   
       </div>
       <div id="vis-filters">
         Filters:

--- a/app/views/visualizations/_vis.html.erb
+++ b/app/views/visualizations/_vis.html.erb
@@ -48,36 +48,29 @@
       <div id="vis-title-bar"
            <% if @presentation || !titleBar %> style="display:none" <% end %>>
         <div class = "row"> 
-          
           <div class = "col-md-8">
-   
-                <button id="ctrls-menu-btn"
-                          class="hamburger-menu btn btn-default down"
-                          <% if !controls %> style="display:none" <% end %>>
-                    <span class="hamburger-bar"></span>
-                    <span class="hamburger-bar"></span>
-                    <span class="hamburger-bar"></span>
-                </button>
-          
-  
-                <div id="vis-title" class="inline-block">
-                  <% if obj %>
-                    <%= title_and_edit_menu(obj) %>
-                  <% else %>
-                    Showing <%= @datasets.count %> Data Sets
-                  <% end %>
-                  <div class="subtitle" style="font-style: italic">
-                    <span>from&nbsp;</span>
-                    <i class='fa fa-folder-open'></i>
-                    <%= link_to project.title.html_safe, project, class: "link" %>
+              <button id="ctrls-menu-btn"
+                        class="hamburger-menu btn btn-default down"
+                        <% if !controls %> style="display:none" <% end %>>
+                  <span class="hamburger-bar"></span>
+                  <span class="hamburger-bar"></span>
+                  <span class="hamburger-bar"></span>
+              </button>
+              <div id="vis-title" class="inline-block">
+                <% if obj %>
+                  <%= title_and_edit_menu(obj) %>
+                <% else %>
+                  Showing <%= @datasets.count %> Data Sets
+                <% end %>
+                <div class="subtitle" style="font-style: italic">
+                  <span>from&nbsp;</span>
+                  <i class='fa fa-folder-open'></i>
+                  <%= link_to project.title.html_safe, project, class: "link" %>
                       by <i class='fa fa-user'></i>
-                    <%= link_to "#{project.owner.name}", owner, class: "link" %>
-                </div>
-
+                  <%= link_to "#{project.owner.name}", owner, class: "link" %>
               </div>
-            
           </div>
-        
+        </div>
           <div class = "col-md-4">
             <div id="vis-title-edit-btn" class="hidden-xs hidden-sm">
               <div class="inline-block subtitle">
@@ -123,7 +116,6 @@
             </div>
           </div>
         </div>
-   
       </div>
       <div id="vis-filters">
         Filters:

--- a/app/views/visualizations/_vis.html.erb
+++ b/app/views/visualizations/_vis.html.erb
@@ -48,7 +48,7 @@
       <div id="vis-title-bar"
            <% if @presentation || !titleBar %> style="display:none" <% end %>>
         <div class = "row"> 
-          <div class = "col-md-8">
+          <div class = "col-md-4">
               <button id="ctrls-menu-btn"
                         class="hamburger-menu btn btn-default down"
                         <% if !controls %> style="display:none" <% end %>>
@@ -71,7 +71,7 @@
               </div>
           </div>
         </div>
-          <div class = "col-md-4">
+          <div class = "col-md-8">
             <div id="vis-title-edit-btn" class="hidden-xs hidden-sm">
               <div class="inline-block subtitle">
                 <% if obj && can_edit?(obj) %>


### PR DESCRIPTION
Issue #2425

Adjusted the way the vis title bar displays, using bootstrap row and sizing elements, making it so that the bar will not be too long.

Also made the edit bar itself disappear when the user changes the screen to a resolution that classifies as 'xs' or 'sm', which fixes an issue I found, where if you changed the size of the screen while editing the title, the bar may overlap with the edge of the screen, creating a weird effect.