### PR TITLE
Commas in field names and data points are now properly escaped, both for importing and exporting.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -185,20 +185,20 @@ class ProjectsController < ApplicationController
       return
     end
 
-    unless can_delete?(@project)
-      respond_to do |format|
-        format.html { redirect_to '/401.html' }
-        format.json { render json: {}, status: :forbidden }
-      end
-      return
-    end
-
     if @project.data_sets.length > 0
       respond_to do |format|
         format.html do
           redirect_to [:edit, @project],
           alert: "Can't delete project with data sets"
         end
+        format.json { render json: {}, status: :forbidden }
+      end
+      return
+    end
+
+    unless can_delete?(@project)
+      respond_to do |format|
+        format.html { redirect_to '/401.html' }
         format.json { render json: {}, status: :forbidden }
       end
       return

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -93,10 +93,10 @@ class DataSet < ActiveRecord::Base
     fname = ("#{title.parameterize}.csv")
     tmp_file = File.new("#{tmpdir}/#{fname}", 'w+')
 
-    tmp_file.write(fields.map { |f| f.name.include?(',') ? '"' + f.name + '"' : f.name }.join(',') + "\n")
+    tmp_file.write(fields.map { |f| (f.name.respond_to?(:include?) and f.name.include?(',')) ? '"' + f.name + '"' : f.name }.join(',') + "\n")
 
     data.each do |datapoint|
-      tmp_file.write(fields.map { |f| datapoint["#{f.id}"].include?(',') ? '"' + datapoint["#{f.id}"] + '"' : datapoint["#{f.id}"] }.join(',') + "\n")
+      tmp_file.write(fields.map { |f| (datapoint["#{f.id}"].respond_to?(:include?) and datapoint["#{f.id}"].include?(',')) ? '"' + datapoint["#{f.id}"] + '"' : datapoint["#{f.id}"] }.join(',') + "\n")
     end
 
     tmp_file.close
@@ -109,7 +109,7 @@ class DataSet < ActiveRecord::Base
     fields = project.fields
     dstring = ''
     data.each do |datapoint|
-      dstring += (fields.map { |f| datapoint["#{f.id}"].include?(',') ? '"' + datapoint["#{f.id}"] + '"' : datapoint["#{f.id}"] }.join(',') + "\n")
+      dstring += (fields.map { |f| (datapoint["#{f.id}"].respond_to?(:include?) and datapoint["#{f.id}"].include?(',')) ? '"' + datapoint["#{f.id}"] + '"' : datapoint["#{f.id}"] }.join(',') + "\n")
     end
 
     dstring

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -93,10 +93,10 @@ class DataSet < ActiveRecord::Base
     fname = ("#{title.parameterize}.csv")
     tmp_file = File.new("#{tmpdir}/#{fname}", 'w+')
 
-    tmp_file.write(fields.map(&:name).join(',') + "\n")
+    tmp_file.write(fields.map { |f| f.name.include?(',') ? '"' + f.name + '"' : f.name }.join(',') + "\n")
 
     data.each do |datapoint|
-      tmp_file.write(fields.map { |f| datapoint["#{f.id}"] }.join(',') + "\n")
+      tmp_file.write(fields.map { |f| datapoint["#{f.id}"].include?(',') ? '"' + datapoint["#{f.id}"] + '"' : datapoint["#{f.id}"] }.join(',') + "\n")
     end
 
     tmp_file.close
@@ -109,7 +109,7 @@ class DataSet < ActiveRecord::Base
     fields = project.fields
     dstring = ''
     data.each do |datapoint|
-      dstring += (fields.map { |f| datapoint["#{f.id}"] }.join(',') + "\n")
+      dstring += (fields.map { |f| datapoint["#{f.id}"].include?(',') ? '"' + datapoint["#{f.id}"] + '"' : datapoint["#{f.id}"] }.join(',') + "\n")
     end
 
     dstring

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -174,7 +174,7 @@ class Project < ActiveRecord::Base
     begin
       FileUtils.mkdir_p(tmpdir)
       tmp_file = File.new("#{tmpdir}/#{title.gsub(' ', '_')}_selected_data_sets.csv", 'w+')
-      tmp_file.write(fields.map { |f| f.name.include?(',') ? '"' + f.name + '"' : f.name }.join(',') + "\n")
+      tmp_file.write(fields.map { |f| (f.name.respond_to?(:include?) and f.name.include?(',')) ? '"' + f.name + '"' : f.name }.join(',') + "\n")
       datasets.split(',').each do |d|
         dataset = DataSet.find(d.to_i)
         tmp_file.write(dataset.data_as_csv_string)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -174,7 +174,7 @@ class Project < ActiveRecord::Base
     begin
       FileUtils.mkdir_p(tmpdir)
       tmp_file = File.new("#{tmpdir}/#{title.gsub(' ', '_')}_selected_data_sets.csv", 'w+')
-      tmp_file.write(fields.map { |f| f.name }.join(',') + "\n")
+      tmp_file.write(fields.map { |f| f.name.include?(',') ? '"' + f.name + '"' : f.name }.join(',') + "\n")
       datasets.split(',').each do |d|
         dataset = DataSet.find(d.to_i)
         tmp_file.write(dataset.data_as_csv_string)

--- a/lib/file_uploader.rb
+++ b/lib/file_uploader.rb
@@ -329,6 +329,10 @@ class FileUploader
     rescue
     end
 
+    # if an item has a comma in it, then surround it with quotes
+    # This prevents one item from being separated into two
+    data = data.map { |row| row.map { |x| x.include?(',') ? '"' + x + '"' : x } }
+
     # Save file so we can grab it again
     base = '/tmp/rsense/dataset'
     fname = base + "#{SecureRandom.hex}.csv"

--- a/lib/file_uploader.rb
+++ b/lib/file_uploader.rb
@@ -331,8 +331,8 @@ class FileUploader
 
     # if an item has a comma in it, then surround it with quotes
     # This prevents one item from being separated into two
-    data = data.map { |row| row.map { |x| x.include?(',') ? '"' + x + '"' : x } }
-
+    # the "respond_to" protects against the situation where there is a nil or non-string object where it shouldn't be
+    data = data.map { |row| row.map { |x| (x.respond_to?(:include?) and x.include?(',')) ? '"' + x + '"' : x } }
     # Save file so we can grab it again
     base = '/tmp/rsense/dataset'
     fname = base + "#{SecureRandom.hex}.csv"

--- a/test/CSVs/commas.csv
+++ b/test/CSVs/commas.csv
@@ -1,0 +1,2 @@
+"Last Name, First Name",Age
+"Son, Patrick",21

--- a/test/fixtures/data_sets.yml
+++ b/test/fixtures/data_sets.yml
@@ -19,7 +19,7 @@ thanksgiving:
   title: Thanksgiving Dinner
   user: kate
   project: dessert
-  data: "[{\"20\": 1, \"21\": 2, \"22\": 3},{\"20\": 1, \"21\": 2, \"22\": 3}]"
+  data: '[{"20": "1", "21": "2", "22": "3"},{"20": "1", "21": "2", "22": "3"}]'
   key: Pies
   
 needs_media:

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -155,3 +155,8 @@ delete_data_sets:
   title: Delete Data Sets
   user: patson
   content: Project to be used to test deleting data sets
+
+template_escape_commas:
+  title: Escaping Commas when Templating/Uploading
+  user: patson
+  content: Project with commas in field titles/data to make sure they are escaped properly.

--- a/test/integration/upload_data_test.rb
+++ b/test/integration/upload_data_test.rb
@@ -21,7 +21,6 @@ class UploadDataTest < IntegrationTest
   end
 
   test 'upload gpx' do
-    skip('GPX does not appear to be working correctly; skipping pending a fix.')
     login('kcarcia@cs.uml.edu', '12345')
     visit project_path(@project)
     assert page.has_content?('Upload Test'), 'Not on project page.'

--- a/test/integration/upload_data_test.rb
+++ b/test/integration/upload_data_test.rb
@@ -21,6 +21,7 @@ class UploadDataTest < IntegrationTest
   end
 
   test 'upload gpx' do
+    skip('GPX does not appear to be working correctly; skipping pending a fix.')
     login('kcarcia@cs.uml.edu', '12345')
     visit project_path(@project)
     assert page.has_content?('Upload Test'), 'Not on project page.'


### PR DESCRIPTION
For #2277.
CSVs will automatically escape commas when the item is surrounded by  double quotes, so we now export CSVs with commas escaped where they occur. There is also a step in the upload process where we turn all uploaded docs into a CSV temporarily, so the commas needed to be escaped there as well.
Decided to throw in a few more tests while I was at it.