### PR TITLE
Edit title box on vis page is now correct width.

### DIFF
--- a/app/assets/stylesheets/visualizations.css.scss
+++ b/app/assets/stylesheets/visualizations.css.scss
@@ -346,6 +346,11 @@ body[data-page-name='visualizations/show'] .visualizations-controller,
           vertical-align: middle;
         }
 
+        // Fix the width of the edit title box
+        #vis-title .input-group {
+          width: 50%;
+        }
+
         #vis-title-edit-btn {
           float: right;
         }


### PR DESCRIPTION
For #2425.
The Edit Title form used to be too long on Chrome and pretty short on other browsers. Now it takes up 50% of the width of its parent container.