### PR TITLE
Renaming a Data set or Visualization with a name longer than 128 characters no longer redirects to a broken page.

### DIFF
--- a/app/controllers/data_sets_controller.rb
+++ b/app/controllers/data_sets_controller.rb
@@ -112,7 +112,7 @@ class DataSetsController < ApplicationController
         format.json { render json: {}, status: :ok }
       else
         @data_set.errors[:base] << 'Permission denied' unless can_edit?(@data_set)
-        format.html { render action: 'edit' }
+        format.html { redirect_to request.referrer, alert: @data_set.errors.full_messages }
         format.json { render json: @data_set.errors.full_messages, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -174,7 +174,7 @@ class VisualizationsController < ApplicationController
         format.json { render json: {}, status: :ok }
       else
         @visualization.errors[:base] << 'Permission denied' unless can_edit?(@visualization)
-        format.html { render action: 'edit' }
+        format.html { redirect_to request.referrer, alert: @visualization.errors.full_messages }
         format.json do
           render json: @visualization.errors.full_messages,
           status: :unprocessable_entity


### PR DESCRIPTION
For #2136.
The issue was that the data_sets_controller was redirecting failed updates to the edit page, instead of where the request came from.
The vis page had a similar issue, which is also fixed here.