### PR TITLE
Double canvas issue fixed

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/map.coffee
+++ b/app/assets/javascripts/visualizations/highvis/map.coffee
@@ -352,7 +352,7 @@ $ ->
 
         checkProj = =>
           if @projOverlay.getProjection() is undefined
-            google.maps.event.addListenerOnce(@gmap, 'idle', checkProj)
+            @idleListener = google.maps.event.addListenerOnce(@gmap, 'idle', checkProj)
           else
             finalInit()
 
@@ -421,7 +421,7 @@ $ ->
           if @timeLines?
             @timeLines[i].setVisible((i in data.groupSelection) and
               Boolean(@configs.visibleLines))
-
+              
         @clusterer.repaint()
         super()
 
@@ -430,6 +430,8 @@ $ ->
         if @gmap?
           @configs.mapType = @gmap.getMapTypeId()
 
+        # Remove the idle listener in case the user switches vis tabs before it fires (see #2201)
+        google.maps.event.removeListener(@idleListener)
         super()
 
       drawControls: ->


### PR DESCRIPTION
For #2201.
If the user clicked away from the map before the listener fired, it would still fire anyway and cause the page to get messed up. Removing the listener on end() fixes it.