### PR TITLE
Long Titles will no longer overflow on Visualization Page

### DIFF
--- a/app/assets/stylesheets/visualizations.css.scss
+++ b/app/assets/stylesheets/visualizations.css.scss
@@ -339,11 +339,12 @@ body[data-page-name='visualizations/show'] .visualizations-controller,
         width: 100%;
         font-size: 1.5em;
         padding: 10px;
-        white-space: nowrap;
+        white-space: normal;
 
         #vis-title {
           margin-left: 10px;
-          vertical-align: middle;
+          vertical-align: middle; 
+          width: 80%;   
         }
 
         #vis-title-edit-btn {

--- a/app/assets/stylesheets/visualizations.css.scss
+++ b/app/assets/stylesheets/visualizations.css.scss
@@ -345,8 +345,9 @@ body[data-page-name='visualizations/show'] .visualizations-controller,
         #vis-title {
           margin-left: 10px;
           vertical-align: middle; 
-          width: 50%;
-          overflow-x: hidden;
+          width: 70%;
+          overflow: hidden;
+        
         }
 
         #vis-title:hover {

--- a/app/assets/stylesheets/visualizations.css.scss
+++ b/app/assets/stylesheets/visualizations.css.scss
@@ -343,7 +343,7 @@ body[data-page-name='visualizations/show'] .visualizations-controller,
         #vis-title {
           margin-left: 10px;
           vertical-align: middle;
-          width: 65%;
+          width: 70%;
           overflow: hidden;  
           white-space: nowrap;
         }

--- a/app/assets/stylesheets/visualizations.css.scss
+++ b/app/assets/stylesheets/visualizations.css.scss
@@ -344,7 +344,6 @@ body[data-page-name='visualizations/show'] .visualizations-controller,
         #vis-title {
           margin-left: 10px;
           vertical-align: middle; 
-          width: 80%;   
         }
 
         #vis-title-edit-btn {

--- a/app/assets/stylesheets/visualizations.css.scss
+++ b/app/assets/stylesheets/visualizations.css.scss
@@ -339,19 +339,17 @@ body[data-page-name='visualizations/show'] .visualizations-controller,
         width: 100%;
         font-size: 1.5em;
         padding: 10px;
-        white-space: nowrap;
-        display: inline-block;
-
+  
         #vis-title {
           margin-left: 10px;
-          vertical-align: middle; 
-          width: 70%;
-          overflow: hidden;
-        
+          vertical-align: middle;
+          width: 65%;
+          overflow: hidden;  
+          white-space: nowrap;
         }
 
         #vis-title:hover {
-          overflow-x: scroll;
+          overflow: auto;
         }
 
         #vis-title-edit-btn {

--- a/app/assets/stylesheets/visualizations.css.scss
+++ b/app/assets/stylesheets/visualizations.css.scss
@@ -339,11 +339,18 @@ body[data-page-name='visualizations/show'] .visualizations-controller,
         width: 100%;
         font-size: 1.5em;
         padding: 10px;
-        white-space: normal;
+        white-space: nowrap;
+        display: inline-block;
 
         #vis-title {
           margin-left: 10px;
           vertical-align: middle; 
+          width: 50%;
+          overflow-x: hidden;
+        }
+
+        #vis-title:hover {
+          overflow-x: scroll;
         }
 
         #vis-title-edit-btn {


### PR DESCRIPTION
Issue #2124 

Edited so vis-title (div which contains the title and subtitle) will only have a width of 70%.

If the text in the title ever exceeds this width, the overflow of text will be hidden.
However, upon hovering over the title, a scroll bar will appear, allowing you to scroll and view the entire title. 

Since the overflow settings are set to auto, the scroll bar will not appear on hover if your title isn't actually overflowing.