### PR TITLE
Vis page correctly redirects to 404.

### DIFF
--- a/test/functional/visualizations_controller_test.rb
+++ b/test/functional/visualizations_controller_test.rb
@@ -101,4 +101,13 @@ class VisualizationsControllerTest < ActionController::TestCase
     assert_response :success
     assert_valid_html response.body
   end
+
+  test 'should redirect to 404' do
+    # Project doesn't exist:
+    get :displayVis, id: 0
+    assert_redirected_to '/404.html'
+    # Data set doesn't belong to project:
+    get :displayVis, id: @vis1.project.id, datasets: [@tgd.id]
+    assert_redirected_to '/404.html'
+  end
 end


### PR DESCRIPTION
For #2474.
The vis page used to break when it was given a project/data set id that did not exist, or if it was given a data set id that did not belong to the selected project.