### PR TITLE
Removed excessive whitespace on manual entry box.

### DIFF
--- a/app/assets/javascripts/data_sets/editTable.js.coffee
+++ b/app/assets/javascripts/data_sets/editTable.js.coffee
@@ -223,10 +223,6 @@ class Grid
     wrapMethod args
 
   resizeWindow: ->
-    newHeight = $(window).height()-
-      $('#row-slickgrid-1').outerHeight() -
-      $('#row-slickgrid-2').outerHeight()
-    $('#slickgrid-container').height newHeight
     @grid.resizeCanvas()
 
   getJSON: ->

--- a/app/assets/stylesheets/data_sets.css.scss
+++ b/app/assets/stylesheets/data_sets.css.scss
@@ -5,7 +5,7 @@
 .data_sets-controller {
 	$slick-border-color: #C0C0C0;
 	$slick-border: thin solid $slick-border-color;
-	$slick-minheight: 400px;
+	$slick-minheight: 412px;
 	$slick-maxheight: 2000px;
 	$slick-defheight: 100%;
 	$slick-row-odd: #FFFFFF;


### PR DESCRIPTION
For #2477.
The Manual entry box no longer has an unnecessary amount of whitespace at the bottom of the grid.