### PR TITLE
Added ruby gem for HTML validation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development, :test do
   gem 'capybara-webkit'
   gem 'minitest', '~> 5.1'
   gem 'capybara-screenshot'
+  gem 'html5_validator'
 end
 
 # Jquery stuff

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,10 @@ GEM
       responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
+    diff-lcs (1.2.5)
     docile (1.1.5)
+    domain_name (0.5.20160615)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.2.2)
     faraday (0.9.2)
@@ -152,6 +155,13 @@ GEM
       tilt
     hashie (3.4.3)
     hike (1.2.3)
+    html5_validator (1.0.0)
+      json
+      rest-client
+      rspec
+      rspec-collection_matchers (~> 1.0.x)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     httparty (0.13.3)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
@@ -186,6 +196,7 @@ GEM
     multi_json (1.11.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    netrc (0.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     oauth2 (1.0.0)
@@ -237,6 +248,10 @@ GEM
     remotipart (1.2.1)
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
+    rest-client (2.0.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rinku (1.5.1)
     rltk (3.0.1)
       ffi (>= 1.0.0)
@@ -245,6 +260,21 @@ GEM
       nokogiri
       rubyzip
       spreadsheet (> 0.6.4)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-collection_matchers (1.1.2)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
     ruby-ole (1.2.11.8)
     ruby-progressbar (1.7.1)
     rubyzip (1.1.7)
@@ -287,6 +317,9 @@ GEM
     uglifier (2.6.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     useragent (0.10.0)
     warden (1.2.3)
       rack (>= 1.0)
@@ -322,6 +355,7 @@ DEPENDENCIES
   font-awesome-rails (~> 4.4.0.0)
   handlebars
   handlebars_assets
+  html5_validator
   httparty
   jqgrid-jquery-rails (~> 4.6.001)
   jquery-drag-rails
@@ -357,4 +391,4 @@ DEPENDENCIES
   yaml_db!
 
 BUNDLED WITH
-   1.11.2
+   1.12.3


### PR DESCRIPTION
Using the ruby gem [html5_validator](https://github.com/damian/html5_validator) for testing. Will delete html5check.py when we're sure it's no longer needed. This validator still uses the same backend service but it handles the output correctly even after it broke for us. If we continue to have problems with using an online service, we should look into getting a local service running. For now, tests are passing again.