### PR TITLE
Regression tooltips have been restored.

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/scatter.coffee
+++ b/app/assets/javascripts/visualizations/highvis/scatter.coffee
@@ -174,7 +174,7 @@ $ ->
             useHTML: true
             # Turning 'shared' on when in scatter fixes Issue #2322.
             # Note that 'shared' doesn't function in scatter mode, but somehow fixes our issue.
-            shared: if @configs.mode is @LINES_MODE then false else true
+            shared: if (@configs.mode is @LINES_MODE or @configs.savedRegressions.length > 0) then false else true
             hideDelay: 0
 
           xAxis: [{
@@ -927,7 +927,7 @@ $ ->
           @addRegressionToTable(savedRegression, true)
 
           # Draw the regression to the vis
-          globals.curVis.delayedUpdate()
+          @start()
 
       # Adds a regression row to our table, with styling for enabled or disabled
       addRegressionToTable: (savedReg, enabled) ->


### PR DESCRIPTION
For #2482.
Regression tooltips were broken in an earlier update.