### PR TITLE
Bar vis x-axis labels are assigned correctly

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -113,9 +113,12 @@ $ ->
               positions
             labels:
               formatter: ->
+                # The bars are always placed in numerical order by ID, so the labels must be as well
+                fieldsInOrder = for fid in data.normalFields when fid in globals.configs.fieldSelection
+                  fid
                 # Only label certain tick marks, and only if there is more than one field selected.
                 if @value % 4 == 0 and globals.configs.fieldSelection.length != 1
-                  fieldTitle(data.fields[globals.configs.fieldSelection[@value / 4]])
+                  fieldTitle(data.fields[fieldsInOrder[@value / 4]])
                 else
                   ""
           legend:

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -107,7 +107,7 @@ $ ->
               # Only place tick marks under the center point of each field cluster
               positions = []
               tick = 0
-              while tick < @dataMax and positions.length < globals.configs.fieldSelection.length
+              while tick <= @dataMax and positions.length < globals.configs.fieldSelection.length
                 positions.push(tick)
                 tick += 4
               positions


### PR DESCRIPTION
For #2478.
The bar labels would be placed in the order that you selected fields, while the bars are always placed in numerical order based on ID. Now, the labels are placed in numerical order as well.