### PR TITLE
Text field is auto-focused when creating project

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -96,7 +96,7 @@
                 <div class="modal-body">
                     <%= f.label :project_name, "Project Name", class:"hidden" %>
                     <%= f.text_field :title, class: "form-control wide-input",
-                        placeholder: "Project Name" %>  
+                        placeholder: "Project Name", :autofocus=>true %>  
                 </div>
                 <div class="modal-footer">
                   <button type = "submit"


### PR DESCRIPTION
For #2484.
Auto-focuses the text entry field after pressing the Create Project fab.