### PR TITLE
Separates bars by dynamic padding rather than fixed borders

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -184,9 +184,11 @@ $ ->
         series = {
           data: datArray
           showInLegend: false # Dummy Legend used instead (see buildLegendSeries())
-          borderWidth: 4
+          borderWidth: 0
           pointWidth: null
-          pointPadding: 0
+          pointPadding: 0.05
+          minPointLength: 2 # Allows tooltips to at least show up on ~0 values
+                            # 2 is the height of the line y=0, so values =0 will not appear as > 0
           groupPadding: 0
           states:
             hover:


### PR DESCRIPTION
Simple fix resolves the issue of borders on bar graphs blocking content by using point padding instead.  [Point padding](http://api.highcharts.com/highcharts/plotOptions.bar.pointPadding) property dynamically manages borders by sizing them as a percentage of the x-axis scale.  As more data points are added, the scale shrinks and so do the spacing.  With the border property, spacing was static.

Also, the line y=0 is colored where a bar of height 0 or close to 0 lies.  This way, tool tips still show up without the borders there.

![bar](https://cloud.githubusercontent.com/assets/17438678/18488373/10acb8c0-79c7-11e6-91ba-31163dc158b5.jpg)