### PR TITLE
Project Title will no longer overflow on Cloning Project page

### DIFF
--- a/app/assets/stylesheets/projects.css.scss
+++ b/app/assets/stylesheets/projects.css.scss
@@ -104,3 +104,7 @@
     padding-top: 50px;
   }
 }
+
+.cloning-panel {
+  word-wrap : break-word;
+}

--- a/app/views/projects/clone.html.erb
+++ b/app/views/projects/clone.html.erb
@@ -13,49 +13,51 @@
     </div>
   <% end %>
 
-  <div class="col-xs-12 col-sm-8 col-sm-offset-2">
-    <%= form_for @clone, url: {action: 'create'} do |ff| %>
-      <div class="panel panel-default">
+<div class="cloning-panel">
+    <div class="col-xs-12 col-sm-8 col-sm-offset-2">
+      <%= form_for @clone, url: {action: 'create'} do |ff| %>
+        <div class="panel panel-default">
 
-        <div class="panel-heading">
-          <h1>Cloning: <%= @project.title.html_safe %></h1>
-        </div>
-
-        <div class="panel-body">
-          <div class="form-group">
-            <%= label_tag(:name, "Title:") %>
-            <%= text_field_tag :project_name,
-                @project.title.html_safe + " (clone)",
-                class: "form-control", autofocus: true %>
+          <div class="panel-heading">
+            <h1>Cloning: <%= @project.title.html_safe %></h1>
           </div>
 
-          <% if @project.data_sets.any? %>
+          <div class="panel-body">
             <div class="form-group">
-              <%= label_tag(:clone_datasets, "Clone Data Sets:") %>
-              <%= check_box_tag :clone_datasets, class: "form-control",
-                  autofocus: true %>
+              <%= label_tag(:name, "Title:") %>
+              <%= text_field_tag :project_name,
+                  @project.title.html_safe + " (clone)",
+                  class: "form-control", autofocus: true %>
             </div>
-          <% end %>
 
-          <div style="text-align:center;">
-            <span style="color:#BBB;">
-              Media objects will automatically be cloned
-              (e.g. photos, text, and files)
-            </span>
+            <% if @project.data_sets.any? %>
+              <div class="form-group">
+                <%= label_tag(:clone_datasets, "Clone Data Sets:") %>
+                <%= check_box_tag :clone_datasets, class: "form-control",
+                    autofocus: true %>
+              </div>
+            <% end %>
+
+            <div style="text-align:center;">
+              <span style="color:#BBB;">
+                Media objects will automatically be cloned
+                (e.g. photos, text, and files)
+              </span>
+            </div>
+
+            <%= hidden_field_tag(:project_id, @project.id) %>
           </div>
 
-          <%= hidden_field_tag(:project_id, @project.id) %>
+          <div class="panel-footer text-center">
+            <a href='<%= url_for @project %>'>
+              <button type="button" class="btn btn-danger"> Cancel </button>
+            </a>
+            <button type="submit" name="commit" class="btn btn-success">
+              Clone Project
+            </button>
+          </div>
         </div>
-
-        <div class="panel-footer text-center">
-          <a href='<%= url_for @project %>'>
-            <button type="button" class="btn btn-danger"> Cancel </button>
-          </a>
-          <button type="submit" name="commit" class="btn btn-success">
-            Clone Project
-          </button>
-        </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
For Issue #2488  

Project title will no longer overflow on cloning page.
See attached image for new behavior.
![screenshot from 2016-09-14 14-14-04](https://cloud.githubusercontent.com/assets/19916403/19528378/c4f24900-95f9-11e6-943c-da54193eb01f.png)
