### PR TITLE
Default category option in edit tutorials set correctly

### DIFF
--- a/app/views/tutorials/_form.html.erb
+++ b/app/views/tutorials/_form.html.erb
@@ -7,7 +7,7 @@
       <div class="col-xs-12" style="margin-top: 10px; margin-bottom: 30px;">
         <%= f.label ':category', 'Categories:'%>
 				<br/>
-        <%= f.select(:category, options_for_select([['Getting Started','Getting Started'], ['Working With Data', 'Working With Data'], ['Visualizations', 'Visualizations']]), class: "form-control") %>
+        <%= f.select(:category, options_for_select([['Getting Started','Getting Started'], ['Working With Data', 'Working With Data'], ['Visualizations', 'Visualizations']], @tutorial.category), class: "form-control") %>
       </div>
       <div class="clear"><br></div>
       <div class="actions col-xs-12">


### PR DESCRIPTION
For #2517.
Before, the default category option when editing a tutorial was always "Getting Started", which could cause you to inadvertently change the category when saving.