### PR TITLE
Auto-detected OS in bug report is more accurate.

### DIFF
--- a/app/views/home/create_issue.html.erb
+++ b/app/views/home/create_issue.html.erb
@@ -30,7 +30,7 @@
         </div>
         <div class="form-group col-md-4">
           <%= label_tag(:os, "Your Operating System:") %>
-          <%= text_field_tag(:os, user_agent.platform, class: "form-control") %>
+          <%= text_field_tag(:os, user_agent.os, class: "form-control") %>
         </div>
         <div class="form-group col-md-4">
           <%= label_tag(:isense_version, "iSENSE Version:") %>


### PR DESCRIPTION
For #2508.
Before, it would just say "Macintosh" or, in the case of Ubuntu 16.04, it would say "X11". Now it should be a bit more accurate, but it isn't perfect (Ubuntu now lists as Linux x86_64; it's not possible for it to say Ubuntu).