### PR TITLE
Fixed CSS so text properly wraps in bug report buttons

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -145,6 +145,10 @@ body {
   }
 }
 
+#github_account, #no_github_account {
+  white-space: normal;
+}
+
 .hidden-form {
   display: none;
 }


### PR DESCRIPTION
There is a width range for which the text on one button wraps and the other doesn't, resulting in differing heights for the buttons, but the text now wraps properly regardless of page width.