### PR TITLE
Added max width to bar chart bars

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -183,13 +183,31 @@ $ ->
             
           xCluster += 4
           pos = 1
+
+        # In order to set a max width to bars, we need to dynamically calculate the pointPadding
+        # If the number of bars is six or greater, we'll stick to the default of 0.05
+        # Else, we'll calculate pointPadding to make the bars the same width as a bar would be
+        #   if there were six bars and a pointPadding of 0.05
+        # To understand pointPadding, think of a bar chart with 5 bars. The width of the graph is
+        #   divided into 5 columns, and the bar is placed inside this column. The bar is centered
+        #   on its respective column, with space on either side (padding) equal to the pointPadding.
+        #   For example, if the pointPadding is 5% (0.05), and there are ten bars, each bar sits in
+        #   a column whose width is 10% of the graph. Each bar itself is 90% of that column, and is
+        #   centered, so that the remaining 5% of the column on either side is reserved for padding.
+        # In the case where there are less than six bars, we want each bar to be equal to 3/20 the
+        #   width of the graph, so the following calculates the padding needed.
+
+        numberOfBars = datArray.length
+        ptPadding = 0.05
+        if numberOfBars < 6
+          ptPadding = 0.5 - (0.075 * numberOfBars)
           
         series = {
           data: datArray
           showInLegend: false # Dummy Legend used instead (see buildLegendSeries())
           borderWidth: 0
           pointWidth: null
-          pointPadding: 0.05
+          pointPadding: ptPadding # In order to set a max width to bars, we need to dynamically calculate the pointPadding
           minPointLength: 2 # Allows tooltips to at least show up on ~0 values
                             # 2 is the height of the line y=0, so values =0 will not appear as > 0
           groupPadding: 0

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -185,17 +185,10 @@ $ ->
           pos = 1
 
         # In order to set a max width to bars, we need to dynamically calculate the pointPadding
-        # If the number of bars is six or greater, we'll stick to the default of 0.05
-        # Else, we'll calculate pointPadding to make the bars the same width as a bar would be
-        #   if there were six bars and a pointPadding of 0.05
-        # To understand pointPadding, think of a bar chart with 5 bars. The width of the graph is
-        #   divided into 5 columns, and the bar is placed inside this column. The bar is centered
-        #   on its respective column, with space on either side (padding) equal to the pointPadding.
-        #   For example, if the pointPadding is 5% (0.05), and there are ten bars, each bar sits in
-        #   a column whose width is 10% of the graph. Each bar itself is 90% of that column, and is
-        #   centered, so that the remaining 5% of the column on either side is reserved for padding.
-        # In the case where there are less than six bars, we want each bar to be equal to 3/20 the
-        #   width of the graph, so the following calculates the padding needed.
+        # If there are less than six bars, make the bars as wide as they would be if there were 
+        #   six bars
+        # NOTE: If/when we upgrade to highcharts v4.1.8 or later, this should be implemented with
+        #   the maxPointWidth parameter instead
 
         numberOfBars = datArray.length
         ptPadding = 0.05

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -185,7 +185,7 @@ $ ->
           pos = 1
 
         # In order to set a max width to bars, we need to dynamically calculate the pointPadding
-        # If there are less than six bars, make the bars as wide as they would be if there were 
+        # If there are less than six bars, make the bars as wide as they would be if there were
         #   six bars
         # NOTE: If/when we upgrade to highcharts v4.1.8 or later, this should be implemented with
         #   the maxPointWidth parameter instead
@@ -200,7 +200,7 @@ $ ->
           showInLegend: false # Dummy Legend used instead (see buildLegendSeries())
           borderWidth: 0
           pointWidth: null
-          pointPadding: ptPadding # In order to set a max width to bars, we need to dynamically calculate the pointPadding
+          pointPadding: ptPadding
           minPointLength: 2 # Allows tooltips to at least show up on ~0 values
                             # 2 is the height of the line y=0, so values =0 will not appear as > 0
           groupPadding: 0


### PR DESCRIPTION
The best way to do this would be to use the maxPointWidth parameter, but that was added in Highcharts v4.1.8 (we're currently using v4.1.5). Instead, I've used dynamically-calculated pointPadding to restrict bars to a certain width. By the nature of these charts, the more bars there are, the more skinny they are, and the less bars there are, the wider they are. This fix makes sure that when going to fewer than six bars, the bars do not get any bigger, they stay the width that they would be if there were six bars.