### PR TITLE
Corrects StdDev formula and tooltip for error bars

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -210,7 +210,8 @@ $ ->
         }
         @chart.addSeries series, false
 
-        # Draw error bars, if option is enabled
+        # Draw "error bars", if option is enabled
+        # Error bars represent +/- 1 standard deviation
         if @configs.analysisType == @ANALYSISTYPE_MEAN_ERROR
           allErrors = []
           xCluster = 0
@@ -235,11 +236,11 @@ $ ->
                 }
               else
                 mean = groupedData[fid][gid]
-                innerStd = barData.map((x) -> (x - mean) ** 2).reduce((x, y) -> x + y)
-                stdDev = Math.sqrt((1 / (barData.length - 1)) * innerStd)
+                variance = barData.map((x) -> (x - mean) ** 2).reduce((x, y) -> x + y) / barData.length
+                stdDev = Math.sqrt(variance)
                 if !globals.configs.logY
                   thisError = {
-                    name: "Error for #{name}"
+                    name: "#{name} \u00B1 1 Standard Deviation"
                     x: xCoord
                     low: mean - stdDev
                     high: mean + stdDev
@@ -248,7 +249,7 @@ $ ->
                   }
                 else if mean > 0
                   thisError = {
-                    name: "Error for #{name}"
+                    name: "{name} + 1 Standard Deviation"
                     x: xCoord
                     low: mean
                     high: mean + stdDev

--- a/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
+++ b/app/assets/javascripts/visualizations/highvis/baseVis.coffee.erb
@@ -61,7 +61,7 @@ $ ->
       SORT_DEFAULT:           -1
 
       analysisTypeNames: ['Total', 'Maximum', 'Mininum', 'Mean (Average)',
-        'Mean with Error', 'Median', 'Row Count']
+        'Mean with Deviation', 'Median', 'Row Count']
 
       ###
       Start sequence used by runtime

--- a/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
+++ b/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
@@ -277,6 +277,11 @@ $ ->
       else
         null
 
+    ###
+    Gets the standard deviation (numeric) value for the given field index.
+    All included datapoints must pass the given filter (defaults to all datapoints).
+    ###
+
     data.getStandardDeviation = (fieldIndex, groupIndices, dp) ->
       if groupIndices?
         if typeof groupIndices is 'number' then groupIndices = [groupIndices]

--- a/doc/release.rb
+++ b/doc/release.rb
@@ -31,7 +31,7 @@ dry = ARGV.include? '-n'
 
 puts "New version will be v#{new_major}.#{new_minor}..."
 
-# puts "Pulling (git pull origin master)..."
+# puts "Pulling (git pull origin master)...."
 # if not dry
 #  puts `cd rSENSE && git pull origin master`
 # end


### PR DESCRIPTION
For issue #2547 

- Error bars simply indicate the positions of plus and minus one standard deviation.  Since standard deviation is not the same as error, the option is now called "Mean with Deviation" and the tooltip reflects appropriately.
- There was a small error in the formula for standard deviation in error bars.  It is fixed to be consistent with the Summary tab.