### PR TITLE
Fixed redirect for failed contributor key creation

### DIFF
--- a/app/controllers/contrib_keys_controller.rb
+++ b/app/controllers/contrib_keys_controller.rb
@@ -22,6 +22,9 @@ class ContribKeysController < ApplicationController
       @errors = @key.errors
 
       flash[:error] = 'Failed to create Contributor Key'
+      @errors.full_messages.each do |e|
+        flash[:error] << '<br>- ' << e
+      end
       redirect_to [:edit, @project]
     end
   end

--- a/app/controllers/contrib_keys_controller.rb
+++ b/app/controllers/contrib_keys_controller.rb
@@ -22,7 +22,7 @@ class ContribKeysController < ApplicationController
       @errors = @key.errors
 
       flash[:error] = 'Failed to create Contributor Key'
-      render 'app/views/projects/_form.html.erb'
+      redirect_to [:edit, @project]
     end
   end
 


### PR DESCRIPTION
For issues #2491 and #2490 

On failure to create a contributor key, the user is redirected to the edit project page (same page they were on) and one error is flashed alerting the user that the key was not created and a list follows with the specific reasons why.
