### PR TITLE
Allow pie charts for datasets without number fields

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
+++ b/app/assets/javascripts/visualizations/highvis/highmodifiers.coffee
@@ -67,6 +67,7 @@ $ ->
 
     data.types ?=
       TIME: 1
+      NUMBER: 2
       TEXT: 3
       LOCATION: [4,5]
 

--- a/app/assets/javascripts/visualizations/highvis/pie.coffee
+++ b/app/assets/javascripts/visualizations/highvis/pie.coffee
@@ -131,6 +131,7 @@ $ ->
         for field of data.fields
           if field["typeID"] == 2 && field["fieldID"] == 1 # if one of the fields is userdefined and numeric
             analyisTypeExcludes = [@ANALYSISTYPE_MEAN_ERROR]
+            break
         @drawToolControls(false, false, analysisTypeExcludes)
         @drawClippingControls()
         @drawSaveControls()

--- a/app/assets/javascripts/visualizations/highvis/pie.coffee
+++ b/app/assets/javascripts/visualizations/highvis/pie.coffee
@@ -40,7 +40,7 @@ $ ->
 
       start: () ->
         @configs.displayField = Math.min globals.configs.fieldSelection...
-        @configs.analysisType ?= @ANALYSISTYPE_TOTAL
+        @configs.analysisType ?= @ANALYSISTYPE_COUNT
         super()
 
       update: () ->
@@ -125,7 +125,13 @@ $ ->
           @drawYAxisControls(globals.configs.fieldSelection,
             data.normalFields.slice(1), true, 'Fields', @configs.displayField,
             @yAxisRadioHandler)
-        @drawToolControls(false, false, [@ANALYSISTYPE_MEAN_ERROR])
+        # If there are no number fields, then restrict pie chart to just row count analysis
+        analysisTypeExcludes = [@ANALYSISTYPE_TOTAL, @ANALYSISTYPE_MAX, @ANALYSISTYPE_MIN,
+          @ANALYSISTYPE_MEAN, @ANALYSISTYPE_MEAN_ERROR, @ANALYSISTYPE_MEDIAN]
+        for field of data.fields
+          if field["typeID"] == 2 && field["fieldID"] == 1 # if one of the fields is userdefined and numeric
+            analyisTypeExcludes = [@ANALYSISTYPE_MEAN_ERROR]
+        @drawToolControls(false, false, analysisTypeExcludes)
         @drawClippingControls()
         @drawSaveControls()
         $('[data-toggle="tooltip"]').tooltip();

--- a/app/assets/javascripts/visualizations/highvis/pie.coffee
+++ b/app/assets/javascripts/visualizations/highvis/pie.coffee
@@ -40,7 +40,7 @@ $ ->
 
       start: () ->
         @configs.displayField = Math.min globals.configs.fieldSelection...
-        @configs.analysisType ?= @ANALYSISTYPE_COUNT
+        @configs.analysisType ?= @ANALYSISTYPE_TOTAL
         super()
 
       update: () ->
@@ -128,9 +128,11 @@ $ ->
         # If there are no number fields, then restrict pie chart to just row count analysis
         analysisTypeExcludes = [@ANALYSISTYPE_TOTAL, @ANALYSISTYPE_MAX, @ANALYSISTYPE_MIN,
           @ANALYSISTYPE_MEAN, @ANALYSISTYPE_MEAN_ERROR, @ANALYSISTYPE_MEDIAN]
-        for field of data.fields
-          if field["typeID"] == 2 && field["fieldID"] == 1 # if one of the fields is userdefined and numeric
-            analyisTypeExcludes = [@ANALYSISTYPE_MEAN_ERROR]
+        @configs.analysisType = @ANALYSISTYPE_COUNT
+        for field in data.fields
+          if field.typeID == data.types.NUMBER && field.fieldID != -1 # if one of the fields is userdefined and numeric
+            analysisTypeExcludes = [@ANALYSISTYPE_MEAN_ERROR]
+            @configs.analysisType = @ANALYSISTYPE_TOTAL
             break
         @drawToolControls(false, false, analysisTypeExcludes)
         @drawClippingControls()

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -407,11 +407,11 @@ class VisualizationsController < ApplicationController
 
     if field_count[NUMBER_TYPE] > 0 and format_data.count > 1
       visualizations.push 'Scatter'
-      visualizations.push 'Pie'
     end
 
     if format_data.count > 0
       visualizations.push 'Bar'
+      visualizations.push 'Pie'
       visualizations.push 'Histogram'
     end
 


### PR DESCRIPTION
Allows the user to view a pie chart for a dataset without user-defined number fields, but restricts them to the row count analysis type. Issue #2561 