### PR TITLE
Clearer tooltips with no "undefined"s

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -63,17 +63,18 @@ $ ->
               
               xField = @series.xAxis.options.title.text
               idx = data.fields.map((x) -> fieldTitle(x)).indexOf(xField)
-              str  = "<div style='width:100%;text-align:center;color:#{@series.color};'> "
-              str += "Bin #{@x}<br>"
+              str  = "<div style='width:100%;text-align:center;'> "
+              str += "<b><u>Bin #{@x}</u></b><br>"
               str += "Contains #{@total} Items<br>"
               str += "Within the Range #{@x - document.getElementById("bin-size").value/2} - #{@x + document.getElementById("bin-size").value/2}</div><br>"
               str += "<table>"  
-              str += "<tr><td style='text-align: right'>Group :&nbsp;</td><td>#{@series.name}</td></tr>"
+              str += "<tr><td style='text-align: right'>Group :&nbsp;</td><td style='color:#{@series.color};'>#{@series.name}</td></tr>"
               if @y > 0
+                console.log @point
                 if @y is 1
-                  str += "<tr><td style='text-align: right'>#{xField} :&nbsp;</td><td>#{@point.realValue}</td></tr>"
+                  str += "<tr><td style='text-align: right'>#{xField} :&nbsp;</td><td style='color:#{@series.color};'>" + (if (@point.realValue == undefined) then "1 in this Bin" else "#{@point.realValue}") + "</td></tr>"
                 else
-                  str += "<tr><td style='text-align: right'>Data Points :&nbsp;</td><td>#{@y} in this Bin</td></tr>"
+                  str += "<tr><td style='text-align: right'>Data Points :&nbsp;</td><td style='color:#{@series.color};'>#{@y} in this Bin</td></tr>"
               str += "</table>"
             useHTML: true
           plotOptions:

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -72,12 +72,13 @@ $ ->
               str += "<tr><td style='text-align: right'>Group :&nbsp;</td>"
               str += "<td style='color:#{@series.color};'>#{@series.name}</td></tr>"
               if @y > 0
-                console.log @point
                 if @y is 1
+                  # Print specific value
                   str += "<tr><td style='text-align: right'>#{xField} :&nbsp;</td><td style='color:#{@series.color};'>"
                   str += if (@point.realValue == undefined) then "1 in this Bin" else "#{@point.realValue}"
                   str += "</td></tr>"
                 else
+                  # Print amount in bin
                   str += "<tr><td style='text-align: right'>Data Points :&nbsp;</td>"
                   str += "<td style='color:#{@series.color};'>#{@y} in this Bin</td></tr>"
               str += "</table>"

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -60,15 +60,18 @@ $ ->
             text: ''
           tooltip:
             formatter: ->
-              str  = "<table>"
+              
               xField = @series.xAxis.options.title.text
               idx = data.fields.map((x) -> fieldTitle(x)).indexOf(xField)
-              str += "<tr><td>#{xField}:</td> <td>#{@point.realValue}</td></tr>"
-              str += "<tr><td>Bin:</td><td>#{@x}</td></tr>"
-              str += "<tr><td># Occurrences:</td><td>#{@total}<td></tr>"
-              if @y isnt 0
-                str += "<tr><td><div style='color:#{@series.color};'> #{@series.name}:</div></td>"
-                str += "<td>#{@y}</td></tr>"
+              str  = "<div style='width:100%;text-align:center;color:#{@series.color};'> "
+              str += "Bin #{@x}<br>Contains #{@total} Items</div><br>"
+              str += "<table>"  
+              str += "<tr><td>Group:&nbsp;</td><td>#{@series.name}</td></tr>"
+              if @y > 0
+                if @y is 1
+                  str += "<tr><td>#{xField}:&nbsp;</td><td>#{@point.realValue}</td></tr>"
+                else
+                  str += "<tr><td>Data Points:&nbsp;</td><td>#{@y} in this Bin</td></tr>"
               str += "</table>"
             useHTML: true
           plotOptions:
@@ -176,6 +179,7 @@ $ ->
         # Generate all bin data
         binObjs = {}
         binMesh = {}
+        binMeans = {}
         dp = globals.getData(true, globals.configs.activeFilters)
         for groupIndex in data.groupSelection
           selectedData = data.selector(@configs.displayField, groupIndex, dp)

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -66,15 +66,20 @@ $ ->
               str  = "<div style='width:100%;text-align:center;'> "
               str += "<b><u>Bin #{@x}</u></b><br>"
               str += "Contains #{@total} Items<br>"
-              str += "Within the Range #{@x - document.getElementById("bin-size").value/2} - #{@x + document.getElementById("bin-size").value/2}</div><br>"
-              str += "<table>"  
-              str += "<tr><td style='text-align: right'>Group :&nbsp;</td><td style='color:#{@series.color};'>#{@series.name}</td></tr>"
+              str += "Within the Range #{@x - document.getElementById("bin-size").value / 2}"
+              str += "- #{@x + document.getElementById("bin-size").value / 2}</div><br>"
+              str += "<table>"
+              str += "<tr><td style='text-align: right'>Group :&nbsp;</td>"
+              str += "<td style='color:#{@series.color};'>#{@series.name}</td></tr>"
               if @y > 0
                 console.log @point
                 if @y is 1
-                  str += "<tr><td style='text-align: right'>#{xField} :&nbsp;</td><td style='color:#{@series.color};'>" + (if (@point.realValue == undefined) then "1 in this Bin" else "#{@point.realValue}") + "</td></tr>"
+                  str += "<tr><td style='text-align: right'>#{xField} :&nbsp;</td><td style='color:#{@series.color};'>"
+                  str += if (@point.realValue == undefined) then "1 in this Bin" else "#{@point.realValue}"
+                  str += "</td></tr>"
                 else
-                  str += "<tr><td style='text-align: right'>Data Points :&nbsp;</td><td style='color:#{@series.color};'>#{@y} in this Bin</td></tr>"
+                  str += "<tr><td style='text-align: right'>Data Points :&nbsp;</td>"
+                  str += "<td style='color:#{@series.color};'>#{@y} in this Bin</td></tr>"
               str += "</table>"
             useHTML: true
           plotOptions:

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -187,7 +187,6 @@ $ ->
         # Generate all bin data
         binObjs = {}
         binMesh = {}
-        binMeans = {}
         dp = globals.getData(true, globals.configs.activeFilters)
         for groupIndex in data.groupSelection
           selectedData = data.selector(@configs.displayField, groupIndex, dp)


### PR DESCRIPTION
For #1470 and #2555
Clearer tooltips for histograms, including range feature and displays count instead of value in the case where histogram blocks are consolidated because bins are large compared to amount of data points.

Note: whether the bins are consolidated is determined based on whether they have a value defined for them