### PR TITLE
Show standard deviation on bar mean with error tooltip

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,6 +391,3 @@ DEPENDENCIES
   will_paginate
   will_paginate-bootstrap
   yaml_db!
-
-BUNDLED WITH
-   1.14.3

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -88,11 +88,14 @@ $ ->
                   str += "color:#{@point.color};margin-bottom:5px'> "
                 str += "<b><u>Group : #{@point.name}</u></b></div>"
                 str += "<table>"
-                str += "<tr><td style='text-align: right'>Analysis Type :&nbsp</td><td>#{self.analysisTypeNames[self.configs.analysisType]}</td></tr>"
-                str += "<tr><td style='text-align: right'>#{@point.field} :&nbsp</td><td>#{@y}</td></tr>"
-                str += "<tr><td style='text-align: right'>Standard Deviation :&nbsp</td><td>± #{@point.stdDev}</td></tr>"
+                str += "<tr><td style='text-align: right'>Analysis Type :&nbsp</td>"
+                str += "<td>#{self.analysisTypeNames[self.configs.analysisType]}</td></tr>"
+                str += "<tr><td style='text-align: right'>#{@point.field} :&nbsp</td>"
+                str += "<td>#{@y}</td></tr>"
+                str += "<tr><td style='text-align: right'>Standard Deviation :&nbsp</td>"
+                str += "<td>± #{@point.stdDev}</td></tr>"
                 #{@point.fieldUnit}</strong></td></tr>"
-                str += "</table>" 
+                str += "</table>"
               # Formatter for error bar tooltips
               else
                 str  = "<div style='width:100%;text-align:center;"
@@ -103,11 +106,12 @@ $ ->
                 str += "<b><u>Error Bar for Group : #{@point.name}</u></b><br>"
                 str += "<b>Bounds Represent Data ± 1 StdDev</b><br></div>"
                 str += "<table>"
-                #str += "<tr><td style='text-align: right'>#{@point.field} :&nbsp</td><td>#{@y} ± #{@point.stdDev}</td></tr>"
-                str += "<tr><td style='text-align: right'>Upper Bound :&nbsp</td><td>#{@y + @point.stdDev}</td></tr>"
-                str += "<tr><td style='text-align: right'>Lower Bound :&nbsp</td><td>#{@y - @point.stdDev}</td></tr>"
+                str += "<tr><td style='text-align: right'>Upper Bound :&nbsp</td>"
+                str += "<td>#{@y + @point.stdDev}</td></tr>"
+                str += "<tr><td style='text-align: right'>Lower Bound :&nbsp</td>"
+                str += "<td>#{@y - @point.stdDev}</td></tr>"
                 #{@point.fieldUnit}</strong></td></tr>"
-                str += "</table>" 
+                str += "</table>"
 
             useHTML: true
           yAxis:

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -37,7 +37,7 @@ $ ->
       start: ->
         @configs.analysisType ?= @ANALYSISTYPE_TOTAL
         @configs.histogramDensity ?= false
-
+        
         # Default Sort
         fs = globals.configs.fieldSelection
         @configs.sortField ?= if fs? then fs[0] else @SORT_DEFAULT
@@ -80,17 +80,23 @@ $ ->
                 #{@point.fieldUnit}</strong></td></tr>"
                 str += "</table>"
               else
+                #console.log("---------------")
+                #console.log(@configs.displayField)
+                #console.log(groupSel)
+                #console.log(dp)
+                #console.log(data.getStandardDeviation(@configs.displayField, groupSel, dp))
+                #console.log("---------------")
                 # Formatter for Bars
                 str  = "<div style='width:100%;text-align:center;"
                 if self.configs.histogramDensity
                   str += "color:#{@point.borderColor};margin-bottom:5px'> "
                 else
                   str += "color:#{@point.color};margin-bottom:5px'> "
-                str += "#{@point.name}</div>"
+                str += "<b><u>Group : #{@point.name}</u></b></div>"
                 str += "<table>"
-                str += "<tr><td>#{@point.field} "
-                str += "(#{self.analysisTypeNames[self.configs.analysisType]}): "
-                str += "</td><td><strong>#{@y} \
+                str += "<tr><td style='text-align: right'>Analysis Type :&nbsp</td><td>#{self.analysisTypeNames[self.configs.analysisType]}</td></tr>"
+                str += "<tr><td style='text-align: right'>#{@point.field} :&nbsp</td><td>#{@y}</td></tr>"
+                #str += "<tr><td style='text-align: right'>Standard Deviation :&nbsp</td><td>± #{@data.getStandardDeviation(@configs.displayField, groupSel, dp)}</td></tr>"
                 #{@point.fieldUnit}</strong></td></tr>"
                 str += "</table>"
             useHTML: true
@@ -236,8 +242,7 @@ $ ->
                 }
               else
                 mean = groupedData[fid][gid]
-                variance = barData.map((x) -> (x - mean) ** 2).reduce((x, y) -> x + y) / barData.length
-                stdDev = Math.sqrt(variance)
+                stdDev = data.getStandardDeviation(fid, gid, dp)
                 if !globals.configs.logY
                   thisError = {
                     name: "#{name} \u00B1 1 Standard Deviation"

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -239,9 +239,10 @@ $ ->
           allErrors = []
           xCluster = 0
           pos = 1
+          dp = globals.getData(true, globals.configs.activeFilters)
           for fid in data.normalFields when fid in fieldSelection
             for gid in sortedGroupIDs when gid in data.groupSelection
-              dp = globals.getData(true, globals.configs.activeFilters)
+              stdDev = data.getStandardDeviation(fid, gid, dp)
               barData = data.selector fid, gid, dp
               xCoord = (xCluster - 1.5) + pos * interval
               name = data.groups[gid] or data.noField()
@@ -252,6 +253,7 @@ $ ->
                 thisError = {
                   name: "#{name}"
                   x: xCoord
+                  stdDev: stdDev
                   low: barData[0]
                   high: barData[0]
                   field: fieldTitle(data.fields[fid])
@@ -259,7 +261,6 @@ $ ->
                 }
               else
                 mean = groupedData[fid][gid]
-                stdDev = data.getStandardDeviation(fid, gid, dp)
                 if !globals.configs.logY
                   thisError = {
                     name: "#{name}"
@@ -274,6 +275,7 @@ $ ->
                   thisError = {
                     name: "{name}"
                     x: xCoord
+                    stdDev: stdDev
                     low: mean
                     high: mean + stdDev
                     field: fieldTitle(data.fields[fid])

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -101,11 +101,11 @@ $ ->
                 else
                   str += "color:#{@point.color};margin-bottom:5px'> "
                 str += "<b><u>Error Bar for Group : #{@point.name}</u></b><br>"
-                str += "Upper and Lower Bounds Represent<br>Data Point ± 1 Standard Deviation<br></div>"
+                str += "<b>Bounds Represent Data ± 1 StdDev</b><br></div>"
                 str += "<table>"
                 #str += "<tr><td style='text-align: right'>#{@point.field} :&nbsp</td><td>#{@y} ± #{@point.stdDev}</td></tr>"
                 str += "<tr><td style='text-align: right'>Upper Bound :&nbsp</td><td>#{@y + @point.stdDev}</td></tr>"
-                str += "<tr><td style='text-align: right'>Lower Bound :&nbsp</td><td>#{@y + @point.stdDev}</td></tr>"
+                str += "<tr><td style='text-align: right'>Lower Bound :&nbsp</td><td>#{@y - @point.stdDev}</td></tr>"
                 #{@point.fieldUnit}</strong></td></tr>"
                 str += "</table>" 
 

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -254,6 +254,7 @@ $ ->
                   fieldUnit: fieldUnit(data.fields[fid], false)
                 }
               else
+                mean = groupedData[fid][gid]
                 stdDev = data.getStandardDeviation(fid, gid, dp)
                 if !globals.configs.logY
                   thisError = {

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -180,10 +180,10 @@ $ ->
         # Bar charts are graphed at explicit x-coordinates instead of
         # implicit (and easier) categories to support the histogram density feature
         datArray = []
+        dp = globals.getData(true, globals.configs.activeFilters)
         for fid in data.normalFields when fid in fieldSelection
           for gid in sortedGroupIDs when gid in data.groupSelection
             xCoord = (xCluster - 1.5) + pos * interval
-            dp = globals.getData(true, globals.configs.activeFilters)
             stdDev = data.getStandardDeviation(fid, gid, dp)
             thisData = {
               x: xCoord

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -255,9 +255,6 @@ $ ->
                 }
               else
                 mean = groupedData[fid][gid]
-                console.log(data)
-                console.log(fid)
-                console.log("***")
                 stdDev = data.getStandardDeviation(fid, gid, dp)
                 if !globals.configs.logY
                   thisError = {
@@ -271,7 +268,7 @@ $ ->
                   }
                 else if mean > 0
                   thisError = {
-                    name: "{name} + 1 Standard Deviation"
+                    name: "{name}"
                     x: xCoord
                     low: mean
                     high: mean + stdDev

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -254,7 +254,6 @@ $ ->
                   fieldUnit: fieldUnit(data.fields[fid], false)
                 }
               else
-                mean = groupedData[fid][gid]
                 stdDev = data.getStandardDeviation(fid, gid, dp)
                 if !globals.configs.logY
                   thisError = {


### PR DESCRIPTION
Fixed bug #2582 
StdDev was calculated manually instead of with the standard function in a different file, so I fixed that; also, I added the standard deviation to the bar tooltip, and tried to improve the error bar tooltip as well.  Pictures attached below.

![new_bar_tooltip](https://cloud.githubusercontent.com/assets/12720180/22564133/5c6160dc-e951-11e6-9eea-006f876f1762.png)
![new_error_bar_tooltip](https://cloud.githubusercontent.com/assets/12720180/22564134/5c642aec-e951-11e6-93c4-14ccb4747384.png)
