### PR TITLE
Use features of active record to reduce queries

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -62,7 +62,7 @@ class ProjectsController < ApplicationController
 
     @cloned_project = Project.select(:id, :user_id, :title).where(id: @project.cloned_from).first
     @liked_by_cur_user = Like.find_by_user_id_and_project_id(current_user, @project.id)
-    @data_sets = @project.data_sets.select('id', 'title', 'user_id', 'key', 'created_at', 'contributor_name').search(params[:search])
+    @data_sets = @project.data_sets.includes(:user).select('id', 'title', 'user_id', 'key', 'created_at', 'contributor_name').search(params[:search])
     @fields = @project.fields
     @field_count = @fields.count
     @formula_fields = @project.formula_fields

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -267,7 +267,7 @@ class VisualizationsController < ApplicationController
         end
       end
     else
-      @datasets = DataSet.where(project_id: params[:id])
+      @datasets = DataSet.includes(:user, :media_objects).where(project_id: params[:id])
     end
 
     # create special row identifier field for all datasets
@@ -325,7 +325,7 @@ class VisualizationsController < ApplicationController
         arr.push "#{dataset.title}(#{dataset.id})"
         arr.push 'All'
         arr.push ''
-        arr.push dataset.key.nil? ? "User: #{User.select(:name).find(dataset.user_id).name}" : "Key: #{dataset.key}"
+        arr.push dataset.key.nil? ? "User: #{dataset.user.name}" : "Key: #{dataset.key}"
         arr.push ''
 
         data_fields.slice(arr.length, data_fields.length).each do |field|

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -14,7 +14,7 @@ class DataSet < ActiveRecord::Base
 
   has_many :media_objects
 
-  belongs_to :project
+  belongs_to :project, inverse_of: :data_sets
   belongs_to :user, counter_cache: true
 
   alias_attribute :name, :title

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,7 +16,8 @@ class Project < ActiveRecord::Base
 
   has_many :fields, dependent: :destroy
   has_many :formula_fields, dependent: :destroy
-  has_many :data_sets, -> { order('created_at desc') }
+  has_many :data_sets, -> { order('created_at desc') },
+    inverse_of: :project
   has_many :media_objects
   has_many :likes
   has_many :visualizations
@@ -143,7 +144,7 @@ class Project < ActiveRecord::Base
       ownerName: owner.nil? ? nil : owner.name,
       ownerUrl: owner.nil? ? nil : UrlGenerator.new.user_url(owner),
       dataSetCount: data_sets.count,
-      dataSetIDs: data_sets.select(:id).map { |ds| ds.id },
+      dataSetIDs: data_sets.pluck(:id),
       fieldCount: fields.count,
       fields: fields.map { |o| o.to_hash false },
       formulaFieldCount: formula_fields.count,
@@ -156,7 +157,7 @@ class Project < ActiveRecord::Base
 
     if recurse
       h.merge!(
-        dataSets:     data_sets.map     { |o| o.to_hash false },
+        dataSets:     data_sets.includes(:user).map     { |o| o.to_hash false },
         mediaObjects: media_objects.map { |o| o.to_hash false },
         owner:        owner.to_hash(false)
       )


### PR DESCRIPTION
#2578
The features used here are includes, inverse_of, and pluck.
- Includes is used to prevent 1+N queries. In this case each DataSet was making a separate query its user.
- Inverse_of helps ActiveRecord reuse existing objects. So in this case the project object will be the same as data_set.project.
- Pluck is an efficient way to return just the value of one field.

On my local instance of iSENSE it reduced a call to /api/v1/projects/1?recur=true request with 608 datasets from 3500ms to around 550ms. 

Most of the extra queries were hitting the query cache, however even hitting the cache takes extra time especially when it results in creating a new model object.