### PR TITLE
Sort-by-name case sensitivity

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,6 +391,3 @@ DEPENDENCIES
   will_paginate
   will_paginate-bootstrap
   yaml_db!
-
-BUNDLED WITH
-   1.14.3

--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -143,7 +143,10 @@ $ ->
         # Otherwise, make sortable key-pairs and sort by the sortField array
         sortedGroupIDs =
           if @configs.sortField is @SORT_DEFAULT
-            i for n, i in data.groups when i in data.groupSelection
+            sortable = []
+            sortable.push [k, v]  for v, k in data.groups when k in data.groupSelection
+            sortable.sort (a,b) -> a[1].toLowerCase().localeCompare(b[1].toLowerCase())
+            Number k for [k, v] in sortable
           else
             sortable = []
             sortable.push [k, v] for k, v of groupedData[@configs.sortField]
@@ -328,7 +331,10 @@ $ ->
         # Otherwise, make sortable key-pairs and sort by the sortField array
         sortedGroupIDs =
           if @configs.sortField is @SORT_DEFAULT
-            i for n, i in data.groups when i in data.groupSelection
+            sortable = []
+            sortable.push [k, v]  for v, k in data.groups when k in data.groupSelection
+            sortable.sort (a,b) -> a[1].toLowerCase().localeCompare(b[1].toLowerCase())
+            Number k for [k, v] in sortable
           else
             sortable = []
             sortable.push [k, v] for k, v of groupedData[@configs.sortField]


### PR DESCRIPTION
Fixed bug #2580 
Default sorting is by name; I elaborated on that sort to make it case insensitive.  Results look something like the following: 

![case_sensitive_fix](https://cloud.githubusercontent.com/assets/12720180/22761247/f107dbb4-ee27-11e6-9054-9c6b11f3e280.png)
