### PR TITLE
Histogram boxes get too small

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -240,6 +240,7 @@ $ ->
               options =
                 showInLegend: false
                 color: globals.getColor(Number(group))
+                borderColor: '#fff'
                 name: data.groups[Number(group)]
                 data: binData
               @chart.addSeries options, false
@@ -263,6 +264,7 @@ $ ->
             options =
               showInLegend: false
               color: globals.getColor(groupIndex)
+              borderColor: globals.getColor(Number(group))
               name: data.groups[groupIndex]
               data: finalData
 


### PR DESCRIPTION
This was a fix for bug #2549 

Basically, I added a few lines of code such that the border around bars remain white if there are less than 100 bars per bin, but otherwise the border color changes to match that of the fill for each bar; otherwise, the histogram is eventually reduced to a big white bar, or a largely white bar with only a few meaningless lines of color.

Here are a few pictures, the first demonstrating a histogram just below the threshold (99 bars), and the second above the threshold (more than 100 bars):

![below_threshold](https://cloud.githubusercontent.com/assets/12720180/23035450/20f56ab4-f44d-11e6-9ef9-726140f2c357.png)
![above_threshhold](https://cloud.githubusercontent.com/assets/12720180/23035452/24270198-f44d-11e6-87a7-14c743648092.png)
