### PR TITLE
Added count to DataSet model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -173,7 +173,7 @@ MethodCallParentheses:
 # Offence count: 78
 # Configuration parameters: CountComments.
 MethodLength:
-  Max: 130 
+  Max: 150
 
 # Offence count: 16
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -269,7 +269,7 @@ class VisualizationsController < ApplicationController
     @datasets.each do |dset|
       total_data_points += dset.count
     end
-    
+
     if total_data_points > 100000
       flash[:danger] = 'Too many data points selected. You may only visualize up to 100,000 data points at one time.'
       respond_to do |format|

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -265,6 +265,20 @@ class VisualizationsController < ApplicationController
                                                           { news: [:user, :media_objects] }, :user]).where(project_id: params[:id])
     end
 
+    total_data_points = 0
+    @datasets.each do |dset|
+      total_data_points += dset.count
+    end
+
+    if total_data_points > 100000
+      flash[:danger] = "Too many data points selected. You may only visualize up to 100,000 data points at one time."
+      respond_to do |format|
+        format.html { redirect_to @project }
+        format.json { render json: { errors: ['Too many data points.'] }, status: 302 }
+      end
+      return
+    end
+
     # create special row identifier field for all datasets
     data_fields.push(typeID: NUMBER_TYPE, unitName: 'id', fieldID: -1, fieldName: 'Data Point')
     # create special dataset grouping field

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -269,9 +269,9 @@ class VisualizationsController < ApplicationController
     @datasets.each do |dset|
       total_data_points += dset.count
     end
-
+    
     if total_data_points > 100000
-      flash[:danger] = "Too many data points selected. You may only visualize up to 100,000 data points at one time."
+      flash[:danger] = 'Too many data points selected. You may only visualize up to 100,000 data points at one time.'
       respond_to do |format|
         format.html { redirect_to @project }
         format.json { render json: { errors: ['Too many data points.'] }, status: 302 }

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -67,7 +67,7 @@ class DataSet < ActiveRecord::Base
       fieldCount: project.fields.length,
       datapointCount: data.length,
       displayURL: "/projects/#{project.id}/data_sets/#{id}",
-      data: data
+      data: data,
       count: count
     }
 

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -223,7 +223,7 @@ class DataSet < ActiveRecord::Base
   end
 
   def update_count
-    self.count = self.data.count
+    self.count = data.count
   end
 
   def self.get_next_name(project, fname)

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -68,6 +68,7 @@ class DataSet < ActiveRecord::Base
       datapointCount: data.length,
       displayURL: "/projects/#{project.id}/data_sets/#{id}",
       data: data
+      count: count
     }
 
     if recurse

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -11,6 +11,7 @@ class DataSet < ActiveRecord::Base
   validates_uniqueness_of :title, message: "\"%{value}\" is taken.", scope: [:project_id]
 
   validates :title, length: { maximum: 128 }
+  validates :count, numericality: { less_than_or_equal_to: 100000, message: 'Maximum size of a data set is 100,000.' }
 
   has_many :media_objects
 
@@ -22,6 +23,7 @@ class DataSet < ActiveRecord::Base
 
   before_validation :sanitize_data_set
   before_validation :recalculate
+  before_validation :update_count
 
   after_create :update_project
 
@@ -218,6 +220,10 @@ class DataSet < ActiveRecord::Base
     end
 
     self.formula_data = dset
+  end
+
+  def update_count
+    self.count = self.data.count
   end
 
   def self.get_next_name(project, fname)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,3 +10,5 @@ en:
         firstname: "First Name"
         lastname: "Last Name"
         password_digest: "Password"
+      data_set:
+        count: ""

--- a/db/migrate/20160922171344_add_counters_to_users.rb
+++ b/db/migrate/20160922171344_add_counters_to_users.rb
@@ -12,8 +12,8 @@ class AddCountersToUsers < ActiveRecord::Migration
   end
 
   def down
-    add_column :users, :projects_count
-    add_column :users, :data_sets_count
-    add_column :users, :visualizations_count
+    remove_column :users, :projects_count, :integer
+    remove_column :users, :data_sets_count, :integer
+    remove_column :users, :visualizations_count, :integer
   end
 end

--- a/db/migrate/20170403144606_add_count_to_data_sets.rb
+++ b/db/migrate/20170403144606_add_count_to_data_sets.rb
@@ -1,0 +1,15 @@
+class AddCountToDataSets < ActiveRecord::Migration
+  def up
+    add_column :data_sets, :count, :integer, default: 0
+
+    say 'Setting count of each data set - This could take a while!'
+    DataSet.find_each do |d|
+      d.count = d.data.count
+      d.save
+    end
+  end
+
+  def down
+    remove_column :data_sets, :count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170306192933) do
+ActiveRecord::Schema.define(version: 20170403144606) do
 
   create_table "contrib_keys", force: true do |t|
     t.string   "name",       null: false
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 20170306192933) do
     t.string   "key"
     t.string   "contributor_name"
     t.text     "formula_data",     default: "[]", null: false
+    t.integer  "count",            default: 0
   end
 
   create_table "fields", force: true do |t|

--- a/test/integration/api_v1_test.rb
+++ b/test/integration/api_v1_test.rb
@@ -7,7 +7,7 @@ class ApiV1Test < IntegrationTest
       %w(ownerName ownerUrl dataSetCount fieldCount fields formulaFieldCount formulaFields dataSetIDs)
     @project_keys_extended = @project_keys + ['dataSets', 'mediaObjects', 'owner']
     @field_keys = ['id', 'name', 'type', 'unit', 'restrictions', 'index', 'refname']
-    @data_keys = ['id', 'name', 'ownerId', 'ownerName', 'contribKey', 'url', 'path', 'createdAt', 'fieldCount', 'datapointCount', 'displayURL', 'data']
+    @data_keys = ['id', 'name', 'ownerId', 'ownerName', 'contribKey', 'url', 'path', 'createdAt', 'fieldCount', 'datapointCount', 'displayURL', 'data', 'count']
     @data_keys_extended = @data_keys + ['owner', 'project', 'fields']
     @dessert_project = projects(:dessert)
     @thanksgiving_dataset = data_sets(:thanksgiving)


### PR DESCRIPTION
For #2606.
Users may now only visualize 100000 data points at a time, and upload a maximum of 100000 data points in each data set. Any more than that and the vis page starts to become unusable with so many data points to parse through, not to mention the strain it puts on the servers.