### PR TITLE
More functionality for admins

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -276,6 +276,16 @@ class UsersController < ApplicationController
     end
   end
 
+  def confirm
+    @user = User.find(params[:id])
+    if @user.confirm!
+      flash[:success] = "User successfully confirmed!"
+    else
+      flash[:error] = "Failed to confirm user..."
+    end
+    redirect_to :back
+  end
+
   # GET /users/pw_reset
   def pw_request
     # Show the form

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 require 'base64'
 
 class UsersController < ApplicationController
-  before_filter :authorize_admin, only: [:index]
+  before_filter :authorize_admin, only: [:index, :confirm]
 
   skip_before_filter :authorize, only: [:show, :index, :pw_request, :pw_send_key, :pw_reset, :contributions]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -279,9 +279,9 @@ class UsersController < ApplicationController
   def confirm
     @user = User.find(params[:id])
     if @user.confirm!
-      flash[:success] = "User successfully confirmed!"
+      flash[:success] = 'User successfully confirmed!'
     else
-      flash[:error] = "Failed to confirm user..."
+      flash[:error] = 'Failed to confirm user...'
     end
     redirect_to :back
   end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -187,7 +187,7 @@
                     <td>
                       <div class="ds_selector" >
                         <label id="lbl_<%=s.id%>" class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect pull-right <%if s.user_id == current_user.try(:id)%> lbl-mine<%end%>" for="ds_<%=s.id%>">
-                          <input type="checkbox" id="ds_<%=s.id%>" class="mdl-checkbox__input<%if s.user_id == current_user.try(:id)%> mine<%end%>" checked>
+                          <input type="checkbox" id="ds_<%=s.id%>" class="mdl-checkbox__input<%if (s.user_id == current_user.try(:id)) or (current_user.try(:admin))%> mine<%end%>" checked>
                         </label>
                       </div>
                     </td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -64,6 +64,13 @@
             <td>
               <%= link_to 'Delete', user_path(u), data: { 
                     :confirm => 'Are you sure you want to delete this account?' }, :method => :delete %>
+              |
+              <%= if u.confirmed_at?
+              then
+                "Confirmed"
+              else
+                link_to 'Confirm', user_path(u), :method => :confirm
+              end %>
             </td>
           </tr>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,4 +135,5 @@ Rsense::Application.routes.draw do
   get '/testing' => 'testing#index'
   post '/testing/review' => 'testing#review'
   post '/testing/publish' => 'testing#publish'
+  post '/users/:id(:confirm)' => 'users#confirm'
 end


### PR DESCRIPTION
For #2670 

- Admins can now "Delete Selected" data sets belonging to other users (but will NEVER do so without user permission or very good reason (eg, offensive, breaking the site, user no longer exists...)
- Admins can now "Confirm" users themselves