### PR TITLE
Fix discrepancy between sort-by drop-down and actual sorting

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/bar.coffee
+++ b/app/assets/javascripts/visualizations/highvis/bar.coffee
@@ -448,10 +448,6 @@ $ ->
         @drawClippingControls()
         @drawSaveControls()
         @drawAnnotationControls()
-        $('[id^=ckbx-y-axis]').click (e) ->
-          fs = globals.configs.fieldSelection
-          if fs and fs.length == 1
-            $('#sort-by').val(fs[0])
         $('[data-toggle="tooltip"]').tooltip();
 
     if "Bar" in data.relVis


### PR DESCRIPTION
Fixes bug #2716. Simply removes code snippet that updates the drop-down based on the current y-axis selections. Now the sort-by does not change from the default unless manually changed.