### PR TITLE
Fix URL and add copy button

### DIFF
--- a/app/views/home/appvis.html.erb
+++ b/app/views/home/appvis.html.erb
@@ -30,9 +30,20 @@
     The last option on the Palette found on the left side of the screen is "Extension".
     Click that, and then click where it says "Import Extension".
     You will be prompted to either import an extension from your computer,
-    or use a URL. Use a URL, paste in the link <%= link_to 'isenseproject.org/aix', '/aix' %>,
+    or use a URL. Use a URL, paste in the link <span id="aix_link"><%= link_to 'http://isenseproject.org/aix', '/aix' %></span>,
     and click "Import" to finish. iSENSEPublisher should be installed, and can be dragged into the
     Viewer just as any other regular component.
+    <br />
+    <script>
+      function copyToClipboard(element) {
+	var $temp = $("<input>");
+	$("body").append($temp);
+	$temp.val($(element).text()).select();
+	document.execCommand("copy");
+	$temp.remove();
+      }
+    </script>
+    <button onClick="copyToClipboard('#aix_link')" > Copy URL</button>
   </div>  
 </div>
 


### PR DESCRIPTION
I added the 'http://' to the app inventor extension link in /appvis.

I also added a button to copy the link to the keyboard, with a short js function embedded into the file. Let me know if there is something wrong with this or that it needs to be changed.