### PR TITLE
Missing end from merge conflict + adding test cases

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -25,6 +25,8 @@ class UserMailer < ActionMailer::Base
     @content = params[:content]
 
     mail(from: from, to: from, Cc: ENV['FRED_EMAIL'], subject: 'Report of inappropriate content on iSENSE.')
+  end
+
   def send_welcome_to(user)
     @user = user
     @hostname = `hostname`.chomp

--- a/test/fixtures/user_mailer/report_content_email.html
+++ b/test/fixtures/user_mailer/report_content_email.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+  </head>
+
+  <body>
+    <h1>REPORT OF INAPPROPRIATE CONTENT ON ISENSE</h1>
+
+    <h3>User ID of reporter (-1 means user not logged in):</h3>
+    <p>
+      1234
+    </p>
+
+    <h3>Reported URL:</h3>
+    <p>
+      https://www.uml.edu
+    </p>
+
+    <h3>Additional Comment: </h3>
+    <p>
+      No wise fish would go anywhere without a porpoise.
+    </p>
+
+    <p><i>Have a nice day!</i></p>
+  </body>
+
+</html>

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -42,4 +42,14 @@ class HomeControllerTest < ActionController::TestCase
     # HTML5 Validation is being skipped until the validator is fixed
     # assert_valid_html response.body
   end
+
+  test 'report inappropriate content should send email' do
+    params = { prev_url: 'https://www.uml.edu', current_user: '1234', content: 'foo' }
+    assert_difference 'ActionMailer::Base.deliveries.size', +1 do
+      post :report_content_submit, params
+    end
+    email = ActionMailer::Base.deliveries.last
+    assert_equal 'Report of inappropriate content on iSENSE.', email.subject
+    assert_equal 'isenseproject@gmail.com', email.to[0]
+  end
 end

--- a/test/unit/user_mailer_test.rb
+++ b/test/unit/user_mailer_test.rb
@@ -21,4 +21,14 @@ class UserMailerTest < ActionMailer::TestCase
     assert_equal 'What about the droid attack on the Wookiees?', email.subject
     assert_equal read_fixture('subscribers.html').join, email.body.to_s.gsub(%r{users/.*/unsubscribe\?token=.*\"}, 'users/foo/unsubscribe?token=bar"')
   end
+
+  # Report inappropriate content
+  test 'report content' do
+    params = { prev_url: 'https://www.uml.edu', current_user: '1234', content: 'No wise fish would go anywhere without a porpoise.' }
+    email = UserMailer.report_content_email(params)
+    assert_equal ['isenseproject@gmail.com'], email.from
+    assert_equal ['isenseproject@gmail.com'], email.to
+    assert_equal 'Report of inappropriate content on iSENSE.', email.subject
+    assert_equal read_fixture('report_content_email.html').join, email.body.to_s
+  end
 end


### PR DESCRIPTION
When merging via github for #2790 , I took out an `end` keyword by mistake.