### PR TITLE
[Dn2648] List for Subscriber Emails

### DIFF
--- a/app/controllers/subscriber_emails_controller.rb
+++ b/app/controllers/subscriber_emails_controller.rb
@@ -1,5 +1,54 @@
 class SubscriberEmailsController < ApplicationController
-  before_filter :authorize_admin, :redirect_cancel, only: [:new, :create]
+  before_filter :authorize_admin, :redirect_cancel, only: [:index, :show, :new, :create]
+
+  def index
+    puts params
+    # Main List
+    if !params[:sort].nil?
+      sort = params[:sort]
+    else
+      sort = 'DESC'
+    end
+
+    if !params[:per_page].nil?
+      pagesize = params[:per_page]
+    else
+      pagesize = 30
+    end
+
+    # constrain results by date
+    start_date = Date.strptime('2013-08-01', '%Y-%m-%d')
+    end_date = Date.today
+    unless params[:start_date].nil?
+      if params[:start_date] != ''
+        start_date = Date.strptime(params[:start_date], '%Y-%m-%d')
+      end
+    end
+    unless params[:end_date].nil?
+      if params[:end_date] != ''
+        end_date = Date.strptime(params[:end_date], '%Y-%m-%d')
+      end
+    end
+
+    @subscriber_emails = SubscriberEmail.where(created_at: start_date.beginning_of_day..end_date.end_of_day)
+    logger.error @subscriber_emails.map(&:created_at)
+
+    @count = @subscriber_emails.count
+    @subscriber_emails = @subscriber_emails.paginate(page: params[:page], per_page: pagesize).order("created_at #{sort}")
+    respond_to do |format|
+      format.html { render status: :ok }
+      format.json { render json: @subscriber_emails.map { |u| u.to_hash(false) }, status: :ok }
+    end
+  end
+
+  def show
+    @subscriber_email = SubscriberEmail.find(params[:id])
+    recur = params.key?(:recur) ? params[:recur] == 'true' : false
+    respond_to do |format|
+      format.html { render status: :ok }
+      format.json { render json: @subscriber_email.to_hash(recur, show_hidden), status: :ok }
+    end
+  end
 
   def new
     @subscriber_email = SubscriberEmail.new

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@
             <li class="navbtn" title="Check out the latest iSENSE news and updates"><%=link_to news_index_path do %><i class='fa fa-newspaper-o'></i> News<%end%></li>
             <% if is_admin? %>
             <li class="navbtn"><%= link_to users_path do%><i class="fa fa-users"></i> Users<%end%></li>
-            <li class="navbtn" title="Send an email to subscribers"><%=link_to new_subscriber_email_path  do %><i class='fa fa-envelope-o' aria-hidden = "true"></i> Email Subscribers<%end%></li>
+            <li class="navbtn"><%=link_to subscriber_emails_path  do %><i class='fa fa-envelope-o' aria-hidden = "true"></i> Subscriber Emails<%end%></li>
             <% end %>
           </ul>
           <ul class="nav navbar-nav navbar-right">

--- a/app/views/subscriber_emails/index.html.erb
+++ b/app/views/subscriber_emails/index.html.erb
@@ -1,0 +1,61 @@
+<div class="row">
+  <div class="col-lg-12">
+    <div class="search-box" id="main_feature">
+      <%=form_tag subscriber_emails_path, method: 'get', id: 'subscriber_emails_search' do%>
+        <!-- hidden input for pagination -->
+        <input type="text" id="hidden_pagination" name="page" value="1" style="display: none;" />
+
+        <div class="row">
+          <div class="col-lg-12">
+            <h1><%= @count %> Email<%= if @count == 1 then "" else "s" end %></h1>
+          </div>
+        
+          <div class="col-lg-4">
+            <select name="sort" class="users_sort_select form-control">
+              <%= options_for_select([["Newest First","DESC"],["Oldest First","ASC"]], 
+                                     params.has_key?(:sort) ? params[:sort] : "DESC") %>
+            </select>
+          </div>
+          <div class="col-lg-6">
+            <%=text_field_tag :search, params[:search], class:'form-control' %>
+          </div>
+          <div class="col-lg-2">
+            <%= submit_tag "Search", name: nil, class:'btn btn-default' %>
+          </div>
+          <div class="col-lg-5" style="margin-top: 3px;">
+            Find Emails from 
+            <%= date_field_tag :start_date, params.has_key?(:start_date) ? params[:start_date] : "2013-08-01" %>
+            To 
+            <%= date_field_tag :end_date, params.has_key?(:end_date) ? params[:end_date] : Date.today %>
+          </div>
+          <div class="clear"></div>
+        </div>
+      <%end%>
+    </div>  
+  </div>
+  <div>
+  <%= link_to("Click here to create and send an email", new_subscriber_email_path) %>
+  </div>
+  <div class="row">
+    <div  class="col-lg-12">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Email</th>
+            <th>Date</th>
+          </tr>
+        </thead>
+          
+        <% @subscriber_emails.each do |u| %>
+        <tr>
+          <th> <%= link_to(u.subject, subscriber_email_path(u)) %> </th>
+          <th> <%= u.created_at %> </th>
+        </tr>
+        <% end %>
+      </table>
+      <div>
+        <%= will_paginate @subscriber_emails%>
+      </div>
+    </div> 
+  </div> 
+</div>

--- a/app/views/subscriber_emails/new.html.erb
+++ b/app/views/subscriber_emails/new.html.erb
@@ -6,7 +6,6 @@ Enter the email
 	<div>
 		Subject: <%= f.text_field :subject %> <br />
 		Message: <%= f.text_area :message, id:'content-area', class: 'summernote'%> <br />
-		</div>
 		<%= f.button :Submit, :label => "Save" %>
 		<%= submit_tag 'Cancel', :name => 'cancel' %>
 		<% end %>

--- a/app/views/subscriber_emails/show.html.erb
+++ b/app/views/subscriber_emails/show.html.erb
@@ -1,0 +1,18 @@
+<div>
+<p>
+	<b><h4>Subject:</h4></b>
+	<%= @subscriber_email.subject %> 
+</p>
+</div>
+<div>
+<p> 
+	<b><h4>Message: </h4></b> 
+	<%= simple_format(@subscriber_email.message)%> 
+</p>
+</div>
+<div>
+<p> 
+	<b><h4>Created at: </h4></b> 
+	<%= @subscriber_email.created_at %>
+</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,6 +144,7 @@ Rsense::Application.routes.draw do
   post '/users/:id/subscribe' => 'users#enable_subscription'
   post '/users/:id/unsubscribe' => 'users#disable_subscription'
   get '/users/:id/unsubscribe' => 'users#disable_subscription_by_email'
-
+  get '/subscriber_emails/new' => 'subscriber_emails#new'
+  get '/subscriber_emails/:id' => 'subscriber_emails#show'
   resources :subscriber_emails
 end


### PR DESCRIPTION
Added a page to view all subscriber emails (Replaced the old top layout Subscriber Emails link - will now take you to the list of subscriber emails instead of the form to create one)

On the list page, you can click on "Click here to create and send an email" to create an email and send it. Also, you can click on the email subject to go to a page to view the subject, message, and date created of the email. 