### PR TITLE
Remove vestigial validation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -266,22 +266,6 @@ class UsersController < ApplicationController
     end
   end
 
-  # GET /users/validate/:key
-  def validate
-    key = params[:key]
-
-    @user = User.find_by_validation_key(key)
-
-    if @user.nil? or params[:key].blank?
-      render_404
-    else
-      @user.validated = true
-      @user.save!
-
-      render
-    end
-  end
-
   def confirm
     @user = User.find(params[:id])
     if @user.confirm!
@@ -371,7 +355,7 @@ class UsersController < ApplicationController
   def user_params
     if current_user.try(:admin)
       params[:user].permit(:content, :email, :email_confirmation, :name, :password, :password_confirmation,
-                           :admin, :validated, :hidden, :bio, :last_login)
+                           :admin, :hidden, :bio, :last_login)
     else
       params[:user].permit(:content, :email, :email_confirmation, :name, :password, :password_confirmation,
                            :hidden, :bio, :subscribed)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,16 +3,6 @@ require 'base64'
 class UserMailer < ActionMailer::Base
   helper ActionView::Helpers::UrlHelper
 
-  def validation_email(user)
-    @user = user
-    @url  = url_for(controller: 'users', action: 'validate', key: @user.validation_key, only_path: false)
-
-    hostname = `hostname`.chomp
-    from = "no-reply@#{hostname}"
-
-    mail(from: from, to: user.email, subject: "Please verify your iSENSE account's email.")
-  end
-
   def pw_reset_email(user)
     user.send_reset_password_instructions
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,7 +3,6 @@
 nixon:
   name: Richard N.
   email: nixon@whitehouse.gov
-  validated: true
   # Password is "12345"
   encrypted_password: <%= Devise::Encryptor.digest(User, '12345') %>
   admin: true
@@ -14,7 +13,6 @@ nixon:
 kate:
   name: Kate C.
   email: kcarcia@cs.uml.edu
-  validated: true
   # Password is "12345"
   encrypted_password: <%= Devise::Encryptor.digest(User, '12345') %>
   admin: false
@@ -25,7 +23,6 @@ kate:
 crunch:
   name: Captain C.
   email: captncrunch@example.com
-  validated: false
   encrypted_password: <%= Devise::Encryptor.digest(User, '12345') %>
   validation_key: abcd
   created_at: <%= 7.day.ago.to_s(:db) %>
@@ -35,7 +32,6 @@ crunch:
 boxes:
   name: boxes
   email: boxes@boxes.boxes
-  validated: true
   encrypted_password: <%= Devise::Encryptor.digest(User, '12345') %>
   admin: false
   created_at: <%= 8.day.ago.to_s(:db) %>
@@ -45,7 +41,6 @@ boxes:
 patson:
   name: Patrick Son
   email: pson@cs.uml.edu
-  validated: true
   encrypted_password: <%= Devise::Encryptor.digest(User, '12345') %>
   admin: false
   created_at: <%= 2.day.ago.to_s(:db) %>
@@ -55,7 +50,6 @@ patson:
 doug:
   name: Doug Salvati
   email: dsalvati@cs.uml.edu
-  validated: true
   encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
   admin: false
   created_at: <%= 3.day.ago.to_s(:db) %>

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -13,11 +13,6 @@ class UserTest < ActiveSupport::TestCase
     assert_default_nil(@user, @user.email)
   end
 
-  # Passes if validated is false
-  test 'validated is false' do
-    assert_default_false(@user, @user.validated)
-  end
-
   # Passes if admin is false
   test 'admin is false' do
     assert_default_false(@user, @user.admin)
@@ -38,10 +33,6 @@ class UserTest < ActiveSupport::TestCase
 
   test 'email' do
     assert_equal 'kcarcia@cs.uml.edu', users(:kate).email
-  end
-
-  test 'validation' do
-    assert_equal true, users(:kate).validated
   end
 
   test 'admin' do


### PR DESCRIPTION
I guess there was an old unused form of what we now use as confirmation via Devise.
References in the code are not needed.
Migration to follow...